### PR TITLE
First version of typeclass support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Builtins are defined in both Scala and Minifumo source files.
 - ANTLR generation task: `generateAntlr` in `build.sbt`
 
 ## Development setup (Codex)
+Always run the full test suite (`sbt test`) before finalizing changes.
 
 Use the following commands to install sbt locally (per the Codex environment setup) and run tests:
 

--- a/doc/examples/typeclasses_ambiguous.minifumo
+++ b/doc/examples/typeclasses_ambiguous.minifumo
@@ -1,0 +1,7 @@
+// Ambiguous instance resolution example.
+
+typeclass Show[T]
+    fun show(value T) String
+
+fun ambiguous[T](value T) String given (s1 Show[T], s2 Show[T])
+    show(value) // error: Ambiguous given for Show[T]

--- a/doc/examples/typeclasses_errors.minifumo
+++ b/doc/examples/typeclasses_errors.minifumo
@@ -1,0 +1,27 @@
+// Examples that should trigger type errors for typeclass handling.
+
+typeclass Show[T]
+    fun show(value T) String
+
+typeclass Show[T] // error: Duplicate typeclass: Show
+    fun show(value T) String
+
+instance showInt1 for Show[Int]
+    fun show(value Int) String
+        "one"
+
+instance showInt2 for Show[Int]
+    fun show(value Int) String
+        "two"
+
+instance showInt1 for Show[Bool] // error: Duplicate instance: showInt1
+    fun show(value Bool) String
+        "dup"
+
+instance badShow for Show[String] // error: Missing member show in instance badShow
+    fun nope(value String) String
+        value
+
+instance badReturn for Show[Bool]
+    fun show(value Bool) Int // error: Member show returns Int, expected String
+        0 // error: Expression has type Int, expected String

--- a/doc/examples/typeclasses_ord.minifumo
+++ b/doc/examples/typeclasses_ord.minifumo
@@ -1,0 +1,49 @@
+// Ord typeclass with instances for Int and MyList.
+
+data MyList[T] = Nil | Cons(head T, tail MyList[T])
+
+typeclass Ord[T]
+    fun lt(a T, b T) Bool
+
+instance ordInt for Ord[Int]
+    fun lt(a Int, b Int) Bool
+        a < b
+
+instance ordList[T] for Ord[MyList[T]] given (o Ord[T])
+    fun lt(a MyList[T], b MyList[T]) Bool
+        match a
+            case Nil
+                match b
+                    case Nil
+                        false
+                    case Cons(_, _)
+                        true
+            case Cons(ah, at)
+                match b
+                    case Nil
+                        false
+                    case Cons(bh, bt)
+                        if lt(ah, bh)
+                            true
+                        else
+                            if lt(bh, ah)
+                                false
+                            else
+                                lt(at, bt)
+
+fun minOf2[T](a T, b T) T given (o Ord[T])
+    if lt(a, b) then a else b
+
+fun minOf3[T](a T, b T, c T) T given (o Ord[T])
+    minOf2(minOf2(a, b), c)
+
+fun main() unit
+    println(minOf3(3, 1, 2))
+    let list1 MyList[Int] = Cons(1, Cons(2, Nil))
+    let list2 MyList[Int] = Cons(1, Cons(3, Nil))
+    let list3 MyList[Int] = Cons(0, Cons(9, Nil))
+    println(minOf3(list1, list2, list3))
+
+// Output:
+// 1
+// Cons(0, Cons(9, Nil))

--- a/doc/examples/typeclasses_sized.minifumo
+++ b/doc/examples/typeclasses_sized.minifumo
@@ -1,0 +1,35 @@
+// Sized typeclass for custom list and tree data types.
+
+data MyList[T] = Nil | Cons(head T, tail MyList[T])
+
+data Tree[T] = Leaf(value T) | Node(left Tree[T], right Tree[T])
+
+typeclass Sized[T]
+    fun size(value T) Int
+
+instance sizedList[T] for Sized[MyList[T]]
+    fun size(value MyList[T]) Int
+        match value
+            case Nil
+                0
+            case Cons(_, tail)
+                1 + size(tail)
+
+instance sizedTree[T] for Sized[Tree[T]]
+    fun size(value Tree[T]) Int
+        match value
+            case Leaf(_)
+                1
+            case Node(left, right)
+                1 + size(left) + size(right)
+
+fun totalSize[T](list MyList[T], tree Tree[T]) Int given (s1 Sized[MyList[T]], s2 Sized[Tree[T]])
+    size(list) + size(tree)
+
+fun main() unit
+    let list MyList[Int] = Cons(1, Cons(2, Nil))
+    let tree Tree[Int] = Node(Leaf(1), Node(Leaf(2), Leaf(3)))
+    println(totalSize[Int](list, tree))
+
+// Output:
+// 7

--- a/src/main/antlr4/Minifumo.g4
+++ b/src/main/antlr4/Minifumo.g4
@@ -180,7 +180,7 @@ typeArgs
   ;
 
 usingClause
-  : 'using' '(' type (',' type)* ')'
+  : 'using' '(' expr (',' expr)* ')'
   ;
 
 

--- a/src/main/scala/com/github/peterzeller/minifumo/ast/Ast.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/ast/Ast.scala
@@ -12,10 +12,31 @@ enum TopLevel:
       typeParams: List[String],
       params: List[FunParam],
       returnType: Option[Type],
+      givenParams: List[FunParam],
       body: Suite
+    )(val source: SourceRange)
+  case TypeClassDecl(
+      name: String,
+      typeParams: List[String],
+      members: List[FunSig]
+    )(val source: SourceRange)
+  case InstanceDecl(
+      name: String,
+      typeParams: List[String],
+      head: Type,
+      givenParams: List[FunParam],
+      members: List[TopLevel.FunDecl]
     )(val source: SourceRange)
 
   def source: SourceRange
+
+final case class FunSig(
+    name: String,
+    typeParams: List[String],
+    params: List[FunParam],
+    returnType: Option[Type],
+    givenParams: List[FunParam]
+  )(val source: SourceRange)
 
 final case class CtorDecl(name: String, fields: List[CtorField])(val source: SourceRange)
 final case class CtorField(name: String, tpe: Type)(val source: SourceRange)
@@ -42,7 +63,7 @@ enum Expr:
   case Block(exprs: List[Expr])(val source: SourceRange)
   // Call is used for both function calls, as well as expressions like "a + b"
   // For example, `a+b` is represented as `Call(Var("+"), List(Var("a"), Var("b")))`
-  case Call(callee: Expr, args: List[Expr])(val source: SourceRange)
+  case Call(callee: Expr, typeArgs: List[Type], args: List[Expr], usingArgs: List[Expr])(val source: SourceRange)
   // Let and Var bindings
   case LetIn(name: String, isConstant: Boolean, tpe: Option[Type], value: Expr, body: Expr)(val source: SourceRange)
   case Bind(name: String, isConstant: Boolean, tpe: Option[Type], value: Expr)(val source: SourceRange)

--- a/src/main/scala/com/github/peterzeller/minifumo/ast/AstTransform.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/ast/AstTransform.scala
@@ -13,6 +13,10 @@ object AstTransform:
   def topLevel(ctx: MinifumoParser.TopLevelContext): TopLevel =
     if ctx.dataDecl() != null then
       dataDecl(ctx.dataDecl())
+    else if ctx.typeClassDecl() != null then
+      typeClassDecl(ctx.typeClassDecl())
+    else if ctx.typeClassImpl() != null then
+      typeClassImpl(ctx.typeClassImpl())
     else
       funDecl(ctx.funDecl())
 
@@ -41,18 +45,48 @@ object AstTransform:
 
   def funDecl(ctx: MinifumoParser.FunDeclContext): TopLevel =
     val sig = ctx.funSig()
-    val name = sig.ID().getText
-    val params = Option(sig.funParams()).map(funParams).getOrElse(Nil)
-    val tParams = Option(sig.typeParams()).map(typeParams).getOrElse(Nil)
-    val returnType = Option(sig.`type`()).map(`type`)
+    val funSigDecl = funSig(sig)
     val body = suite(ctx.suite())
-    TopLevel.FunDecl(name, tParams, params, returnType, body)(range(ctx))
+    TopLevel.FunDecl(
+      funSigDecl.name,
+      funSigDecl.typeParams,
+      funSigDecl.params,
+      funSigDecl.returnType,
+      funSigDecl.givenParams,
+      body
+    )(range(ctx))
+
+  def funSig(ctx: MinifumoParser.FunSigContext): FunSig =
+    val name = ctx.ID().getText
+    val params = Option(ctx.funParams()).map(funParams).getOrElse(Nil)
+    val tParams = Option(ctx.typeParams()).map(typeParams).getOrElse(Nil)
+    val returnType = Option(ctx.`type`()).map(`type`)
+    val givenParams = Option(ctx.givenClause()).map(givenClause).getOrElse(Nil)
+    FunSig(name, tParams, params, returnType, givenParams)(range(ctx))
+
+  def typeClassDecl(ctx: MinifumoParser.TypeClassDeclContext): TopLevel =
+    val name = ctx.ID().getText
+    val tParams = Option(ctx.typeParams()).map(typeParams).getOrElse(Nil)
+    val members = Option(ctx.typeClassSigBlock()).map(typeClassSigBlock).getOrElse(Nil)
+    TopLevel.TypeClassDecl(name, tParams, members)(range(ctx))
+
+  def typeClassImpl(ctx: MinifumoParser.TypeClassImplContext): TopLevel =
+    val name = ctx.name.getText
+    val tParams = Option(ctx.typeParams()).map(typeParams).getOrElse(Nil)
+    val typeClassName = ctx.ID().get(1).getText
+    val head = typeClassHead(typeClassName, Option(ctx.typeArgs()).map(typeArgs).getOrElse(Nil), range(ctx))
+    val givenParams = Option(ctx.givenClause()).map(givenClause).getOrElse(Nil)
+    val members = Option(ctx.typeClassImplBlock()).map(typeClassImplBlock).getOrElse(Nil)
+    TopLevel.InstanceDecl(name, tParams, head, givenParams, members)(range(ctx))
 
   def funParams(ctx: MinifumoParser.FunParamsContext): List[FunParam] =
     ctx.funParam().asScala.toList.map(funParam)
 
   def funParam(ctx: MinifumoParser.FunParamContext): FunParam =
     FunParam(ctx.ID().getText, `type`(ctx.`type`()))(range(ctx))
+
+  def givenClause(ctx: MinifumoParser.GivenClauseContext): List[FunParam] =
+    funParams(ctx.funParams())
 
   def suite(ctx: MinifumoParser.SuiteContext): Suite =
     Suite.Block(block(ctx.block()))(range(ctx))
@@ -85,7 +119,9 @@ object AstTransform:
         Expr.Paren(expr(c.expr()))(range(c))
       case c: MinifumoParser.CallContext =>
         val args = Option(c.argList()).map(argList).getOrElse(Nil)
-        Expr.Call(expr(c.expr()), args)(range(c))
+        val tArgs = Option(c.typeArgs()).map(typeArgs).getOrElse(Nil)
+        val usingArgs = Option(c.usingClause()).map(usingClause).getOrElse(Nil)
+        Expr.Call(expr(c.expr()), tArgs, args, usingArgs)(range(c))
       case c: MinifumoParser.DotContext =>
         // The expression x.f(a,b,c) is short for f(x,a,b,c)
         opCall(c.ID().getText(), expr(c.expr()) :: argList(c.argList()), range(c))
@@ -142,6 +178,12 @@ object AstTransform:
   def argList(ctx: MinifumoParser.ArgListContext): List[Expr] =
     ctx.expr().asScala.toList.map(expr)
 
+  def typeArgs(ctx: MinifumoParser.TypeArgsContext): List[Type] =
+    ctx.`type`().asScala.toList.map(`type`)
+
+  def usingClause(ctx: MinifumoParser.UsingClauseContext): List[Expr] =
+    ctx.expr().asScala.toList.map(expr)
+
   def matchCase(ctx: MinifumoParser.MatchCaseContext): MatchCase =
     MatchCase(pattern(ctx.pattern()), suite(ctx.suite()))(range(ctx))
 
@@ -172,6 +214,20 @@ object AstTransform:
   def patternArgs(ctx: MinifumoParser.PatternArgsContext): List[Pattern] =
     ctx.pattern().asScala.toList.map(pattern)
 
+  def typeClassSigBlock(ctx: MinifumoParser.TypeClassSigBlockContext): List[FunSig] =
+    ctx.funSig().asScala.toList.map(funSig)
+
+  def typeClassImplBlock(ctx: MinifumoParser.TypeClassImplBlockContext): List[TopLevel.FunDecl] =
+    ctx.funDecl().asScala.toList.map { funDecl =>
+      val sig = funSig(funDecl.funSig())
+      TopLevel.FunDecl(sig.name, sig.typeParams, sig.params, sig.returnType, sig.givenParams, suite(funDecl.suite()))(
+        range(funDecl)
+      )
+    }
+
+  private def typeClassHead(name: String, args: List[Type], source: SourceRange): Type =
+    if args.isEmpty then Type.Name(name)(source) else Type.App(Type.Name(name)(source), args)(source)
+
   private def unquote(text: String): String =
     if text.length >= 2 && text.head == '"' && text.last == '"' then
       text.substring(1, text.length - 1)
@@ -179,7 +235,7 @@ object AstTransform:
       text
 
   private def opCall(name: String, args: List[Expr], source: SourceRange): Expr =
-    Expr.Call(Expr.Var(name)(source), args)(source)
+    Expr.Call(Expr.Var(name)(source), Nil, args, Nil)(source)
 
   private def suiteToExpr(s: Suite): Expr =
     s match

--- a/src/main/scala/com/github/peterzeller/minifumo/interpreter/Interpreter.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/interpreter/Interpreter.scala
@@ -15,6 +15,8 @@ object Interpreter:
     case SetVal(value: Set[Value])
     case MapVal(value: Map[Value, Value])
     case AdtVal(name: String, args: List[Value])
+    // Maps member names to their implementation plus any captured given arguments.
+    case InstanceVal(members: Map[String, InstanceMemberValue])
     case UnitVal
     case FuncVal(fn: (List[Value], Env) => (Value, Env))
     case UndefinedVal
@@ -24,10 +26,14 @@ object Interpreter:
 
   final case class FunDef(params: List[ParamSymbol], body: Suite)
 
+  // Captured holds resolved given arguments for the instance member.
+  final case class InstanceMemberValue(symbol: FunctionSymbol, captured: List[Value])
+
   final case class Env(
       scopes: List[Map[TermSymbol, Value]],
       functions: Map[FunctionSymbol, FunDef],
-      ctors: Map[CtorSymbol, Int]
+      ctors: Map[CtorSymbol, Int],
+      instances: Map[InstanceSymbol, TopLevel.InstanceDecl]
     ):
     def resolve(symbol: TermSymbol): Option[Value] =
       scopes.collectFirst { case scope if scope.contains(symbol) => scope(symbol) }.orElse(baseValue(symbol))
@@ -69,7 +75,7 @@ object Interpreter:
 
   def evalProg(program: Program, entryName: String): Value =
     val env = buildEnv(program)
-    val entrySymbol = program.items.collectFirst { case TopLevel.FunDecl(symbol, _, _, _) if symbol.name == entryName => symbol }
+    val entrySymbol = program.items.collectFirst { case TopLevel.FunDecl(symbol, _, _, _, _) if symbol.name == entryName => symbol }
       .getOrElse(throw new IllegalArgumentException(s"Unknown function: $entryName"))
     val (value, _) = evalFunc(entrySymbol, Nil, env)
     value
@@ -112,6 +118,17 @@ object Interpreter:
         (literalValue(value), env)
       case Expr.Var(symbol, _) =>
         val value = symbol match
+          case instance: InstanceSymbol =>
+            env.instances.get(instance) match
+              case Some(instanceDecl) if instance.givenParams.isEmpty =>
+                val members = instanceDecl.members.map { member =>
+                  member.memberName -> InstanceMemberValue(member.symbol, Nil)
+                }.toMap
+                Value.InstanceVal(members)
+              case Some(_) =>
+                throw new IllegalArgumentException(s"Instance ${instance.name} requires given arguments")
+              case None =>
+                throw new IllegalArgumentException(s"Unknown instance: ${instance.name}")
           case term: TermSymbol =>
             env.resolve(term).getOrElse(throw new IllegalArgumentException(s"Unknown variable: ${term.name}"))
           case fun: FunctionSymbol =>
@@ -135,7 +152,7 @@ object Interpreter:
           currentEnv = envAfter
         }
         (lastValue, currentEnv)
-      case Expr.CallFun(callee, args, _) =>
+      case Expr.CallFun(callee, args, givenArgs, _) =>
         callee match
           case Expr.Var(symbol, _) if symbol.name == "." && args.length == 2 =>
             val (target, envAfterTarget) = evalExpr(args.head, env)
@@ -147,8 +164,9 @@ object Interpreter:
           case _ =>
             val (calleeValue, envAfterCallee) = evalExpr(callee, env)
             val (argValues, envAfterArgs) = evalArgs(args, envAfterCallee)
+            val (givenValues, envAfterGivens) = evalArgs(givenArgs, envAfterArgs)
             calleeValue match
-              case Value.FuncVal(fn) => fn(argValues, envAfterArgs)
+              case Value.FuncVal(fn) => fn(argValues ++ givenValues, envAfterGivens)
               case other => throw new IllegalArgumentException(s"Call target must be a function, got: $other")
       case Expr.CallCtor(symbol, args, _) =>
         val (argValues, envAfterArgs) = evalArgs(args, env)
@@ -157,6 +175,28 @@ object Interpreter:
             s"Constructor ${symbol.name} expects ${symbol.arity} args, got ${argValues.length}"
           )
         (Value.AdtVal(symbol.name, argValues), envAfterArgs)
+      case Expr.InstanceValue(symbol, givenArgs, _) =>
+        env.instances.get(symbol) match
+          case Some(instanceDecl) =>
+            val (givenValues, envAfterGivens) = evalArgs(givenArgs, env)
+            val members = instanceDecl.members.map { member =>
+              member.memberName -> InstanceMemberValue(member.symbol, givenValues)
+            }.toMap
+            (Value.InstanceVal(members), envAfterGivens)
+          case None =>
+            throw new IllegalArgumentException(s"Unknown instance: ${symbol.name}")
+      case Expr.CallTypeClassMember(instanceExpr, memberName, args, _) =>
+        val (instanceValue, envAfterInstance) = evalExpr(instanceExpr, env)
+        val (argValues, envAfterArgs) = evalArgs(args, envAfterInstance)
+        instanceValue match
+          case Value.InstanceVal(members) =>
+            members.get(memberName) match
+              case Some(InstanceMemberValue(memberSymbol, captured)) =>
+                evalFunc(memberSymbol, argValues ++ captured, envAfterArgs)
+              case None =>
+                throw new IllegalArgumentException(s"Unknown instance member: $memberName")
+          case other =>
+            throw new IllegalArgumentException(s"Expected typeclass instance, got: $other")
       case Expr.LetIn(symbol, _, _, valueExpr, bodyExpr, _) =>
         val (value, envAfterValue) = evalExpr(valueExpr, env)
         val envWithBinding = envAfterValue.pushScope(Map(symbol -> value))
@@ -243,15 +283,23 @@ object Interpreter:
   private def buildEnv(program: Program): Env =
     var functions = Map.empty[FunctionSymbol, FunDef]
     var ctors = Map.empty[CtorSymbol, Int]
+    var instances = Map.empty[InstanceSymbol, TopLevel.InstanceDecl]
     program.items.foreach {
           case TopLevel.DataDecl(_, _, constructors) =>
             constructors.foreach { ctor =>
               ctors = ctors + (ctor.symbol -> ctor.symbol.arity)
             }
-          case TopLevel.FunDecl(symbol, _, params, body) =>
-            functions = functions + (symbol -> FunDef(params, body))
+          case TopLevel.FunDecl(symbol, _, params, givenParams, body) =>
+            functions = functions + (symbol -> FunDef(params ++ givenParams, body))
+          case instanceDecl: TopLevel.InstanceDecl =>
+            instances = instances + (instanceDecl.symbol -> instanceDecl)
+            instanceDecl.members.foreach { member =>
+              functions = functions + (member.symbol -> FunDef(member.params, member.body))
+            }
+          case _: TopLevel.TypeClassDecl =>
+            ()
         }
-    Env(List(Map.empty), functions, ctors)
+    Env(List(Map.empty), functions, ctors, instances)
 
   private val baseValues: Map[String, Value] =
     Map(
@@ -499,6 +547,7 @@ object Interpreter:
       case Value.SetVal(values) => values.map(renderValue).mkString("Set(", ", ", ")")
       case Value.MapVal(values) =>
         values.map { case (k, v) => s"${renderValue(k)}: ${renderValue(v)}" }.mkString("Map(", ", ", ")")
+      case Value.InstanceVal(_) => "<instance>"
       case Value.AdtVal(name, args) =>
         if args.isEmpty then name else s"$name${args.map(renderValue).mkString("(", ", ", ")")}"
       case Value.UnitVal => "unit"

--- a/src/main/scala/com/github/peterzeller/minifumo/typing/TypeChecker.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/typing/TypeChecker.scala
@@ -11,17 +11,41 @@ object TypeChecker:
 
   final case class DataType(name: String, typeParams: List[String], ctors: List[CtorSymbol])
 
+  // Stores member signatures without creating function symbols during the export pass.
+  final case class TypeClassMemberSig(
+      name: String,
+      typeParams: List[String],
+      params: List[Type],
+      result: Type
+    )
+
+  // Typeclass definitions are tracked in the type checker export environment.
+  final case class TypeClassDef(name: String, typeParams: List[String], members: List[TypeClassMemberSig])
+
+  final case class InstanceDef(
+      symbol: InstanceSymbol,
+      typeParams: List[String],
+      head: Type,
+      givenTypes: List[Type],
+      members: Map[String, ast.TopLevel.FunDecl]
+    )
+
   final case class ExportEnv(
       functions: Map[String, FunctionSymbol],
       ctors: Map[String, CtorSymbol],
-      types: Map[String, DataType]
+      types: Map[String, DataType],
+      typeClasses: Map[String, TypeClassDef],
+      instances: Map[String, InstanceDef],
+      // Member name -> typeclasses that declare it (used for implicit member resolution).
+      memberIndex: Map[String, List[TypeClassDef]]
     )
 
   final case class TypeEnv(
       scopes: List[Map[String, TermSymbol]],
       exports: ExportEnv,
       typeParams: Set[String],
-      expectedReturn: Type
+      expectedReturn: Type,
+      givens: List[ParamSymbol]
     ):
     def withBinding(symbol: TermSymbol): TypeEnv =
       scopes match
@@ -97,6 +121,20 @@ object TypeChecker:
           )(ctor.source)
         }
         TopLevel.DataDecl(dataDecl.name, dataDecl.typeParams, ctorDecls)(dataDecl.source)
+      case typeClassDecl: ast.TopLevel.TypeClassDecl =>
+        val members = typeClassDecl.members.map { member =>
+          TypeClassMember(
+            member.name,
+            member.typeParams,
+            member.params.map(p => fromAstType(p.tpe)),
+            member.returnType.map(fromAstType).getOrElse(Type.Unknown)
+          )(member.source)
+        }
+        TopLevel.TypeClassDecl(typeClassDecl.name, typeClassDecl.typeParams, members)(typeClassDecl.source)
+      case instanceDecl: ast.TopLevel.InstanceDecl =>
+        val (typedInstance, instanceErrors) = typeInstance(instanceDecl, exports)
+        errors ++= instanceErrors
+        typedInstance
     }
     (Program(typedItems)(program.source), errors.toList)
 
@@ -105,6 +143,9 @@ object TypeChecker:
     var functions = Map.empty[String, FunctionSymbol]
     var ctors = Map.empty[String, CtorSymbol]
     var types = Map.empty[String, DataType]
+    var typeClasses = Map.empty[String, TypeClassDef]
+    var instances = Map.empty[String, InstanceDef]
+    var memberIndex = Map.empty[String, List[TypeClassDef]]
 
     for item <- program.items do {
       item match
@@ -135,28 +176,90 @@ object TypeChecker:
         types = types + (name -> DataType(name, typeParams, ctorSymbols))
         ctorDecls.foreach { ctor =>
           ctor.fields.foreach { field =>
-            errors ++= validateAstType(field.tpe, typeParams.toSet, ExportEnv(functions, ctors, types))
+            errors ++= validateAstType(field.tpe, typeParams.toSet, ExportEnv(functions, ctors, types, typeClasses, instances, memberIndex))
           }
         }
-      case ast.TopLevel.FunDecl(name, typeParams, params, returnType, _) =>
+      case funDecl @ ast.TopLevel.FunDecl(name, typeParams, params, returnType, _, _) =>
         if functions.contains(name) then
           errors += errorAt(item.source, s"Duplicate function: $name")
         val paramTypes = params.map(p => fromAstType(p.tpe))
+        val givenTypes = funGivenTypes(funDecl)
         val returnTpe = returnType.map(fromAstType).getOrElse {
           errors += errorAt(item.source, s"Missing return type for function: $name")
           Type.Unknown
         }
-        val funSymbol = FunctionSymbol(name, typeParams, Type.Fun(paramTypes, returnTpe))
+        val funSymbol = FunctionSymbol(name, typeParams, Type.Fun(paramTypes, returnTpe), givenTypes)
         functions = functions + (name -> funSymbol)
         val typeParamSet = typeParams.toSet
         params.foreach { param =>
-          errors ++= validateAstType(param.tpe, typeParamSet, ExportEnv(functions, ctors, types))
+          errors ++= validateAstType(param.tpe, typeParamSet, ExportEnv(functions, ctors, types, typeClasses, instances, memberIndex))
+        }
+        funDecl.givenParams.foreach { param =>
+          errors ++= validateAstType(param.tpe, typeParamSet, ExportEnv(functions, ctors, types, typeClasses, instances, memberIndex))
         }
         returnType.foreach { tpe =>
-          errors ++= validateAstType(tpe, typeParamSet, ExportEnv(functions, ctors, types))
+          errors ++= validateAstType(tpe, typeParamSet, ExportEnv(functions, ctors, types, typeClasses, instances, memberIndex))
         }
+      case ast.TopLevel.TypeClassDecl(name, typeParams, members) =>
+        if typeClasses.contains(name) then
+          errors += errorAt(item.source, s"Duplicate typeclass: $name")
+        val memberSigs = members.map { member =>
+          if member.givenParams.nonEmpty then
+            errors += errorAt(member.source, s"Typeclass member ${member.name} cannot declare given parameters")
+          if member.returnType.isEmpty then
+            errors += errorAt(member.source, s"Missing return type for member: ${member.name}")
+          TypeClassMemberSig(
+            member.name,
+            member.typeParams,
+            member.params.map(p => fromAstType(p.tpe)),
+            member.returnType.map(fromAstType).getOrElse(Type.Unknown)
+          )
+        }
+        typeClasses = typeClasses + (name -> TypeClassDef(name, typeParams, memberSigs))
+        memberSigs.foreach { member =>
+          val typeParamSet = (typeParams ++ member.typeParams).toSet
+          member.params.foreach { param =>
+            errors ++= validateTypedType(param, typeParamSet, ExportEnv(functions, ctors, types, typeClasses, instances, memberIndex), item.source)
+          }
+          errors ++= validateTypedType(member.result, typeParamSet, ExportEnv(functions, ctors, types, typeClasses, instances, memberIndex), item.source)
+        }
+      case ast.TopLevel.InstanceDecl(name, typeParams, head, givenParams, members) =>
+        if instances.contains(name) then
+          errors += errorAt(item.source, s"Duplicate instance: $name")
+        val headType = fromAstType(head)
+        val givenTypes = givenParams.map(p => fromAstType(p.tpe))
+        val memberMap = members.map(m => m.name -> m).toMap
+        val instanceSymbol = InstanceSymbol(name, typeParams, headType, givenTypes, Map.empty)
+        instances = instances + (name -> InstanceDef(instanceSymbol, typeParams, headType, givenTypes, memberMap))
     }
-    (ExportEnv(functions, ctors, types), errors.toList)
+    memberIndex = typeClasses.values
+      .flatMap(tc => tc.members.map(_.name).distinct.map(_ -> tc))
+      .groupBy(_._1)
+      .view
+      .mapValues(_.map(_._2).toList)
+      .toMap
+
+    val updatedInstances = instances.map { case (name, instance) =>
+      val (typeClassName, typeClassArgs) = instance.head match
+        case Type.App(Type.Name(tcName), args) => (tcName, args)
+        case Type.Name(tcName) => (tcName, Nil)
+        case _ => ("", Nil)
+      val typeClassMembers = typeClasses.get(typeClassName).map { tc =>
+        val subst = tc.typeParams.zip(typeClassArgs).toMap
+        tc.members.map { member =>
+          val params = member.params.map(param => instantiateType(param, subst))
+          val result = instantiateType(member.result, subst)
+          val funType: Type.Fun = Type.Fun(params ++ instance.givenTypes, result)
+          member.name -> FunctionSymbol(s"${instance.symbol.name}.${member.name}", member.typeParams, funType, Nil)
+        }.toMap
+      }.getOrElse(Map.empty[String, FunctionSymbol])
+      val symbol = instance.symbol.copy(members = typeClassMembers)
+      name -> instance.copy(symbol = symbol)
+    }
+    (ExportEnv(functions, ctors, types, typeClasses, updatedInstances, memberIndex), errors.toList)
+
+  private def funGivenTypes(funDecl: ast.TopLevel.FunDecl): List[Type] =
+    funDecl.givenParams.map(p => fromAstType(p.tpe))
 
   def typeFunction(
       funDecl: ast.TopLevel.FunDecl,
@@ -166,24 +269,138 @@ object TypeChecker:
     val idSupply = new IdSupply
     val funSymbol = exports.functions.getOrElse(
       funDecl.name,
-      FunctionSymbol(funDecl.name, funDecl.typeParams, Type.Fun(Nil, Type.Unknown))
+      FunctionSymbol(funDecl.name, funDecl.typeParams, Type.Fun(Nil, Type.Unknown), Nil)
     )
     val paramsWithSource = funDecl.params.map { param =>
+      (param, ParamSymbol(param.name, fromAstType(param.tpe), idSupply.freshId()))
+    }
+    val givenWithSource = funDecl.givenParams.map { param =>
       (param, ParamSymbol(param.name, fromAstType(param.tpe), idSupply.freshId()))
     }
     val duplicateParams = funDecl.params.groupBy(_.name).collect { case (_, ps) if ps.length > 1 => ps }
     duplicateParams.flatten.foreach { param =>
       errors += errorAt(param.source, s"Duplicate parameter: ${param.name}")
     }
+    val duplicateGivens = funDecl.givenParams.groupBy(_.name).collect { case (_, ps) if ps.length > 1 => ps }
+    duplicateGivens.flatten.foreach { param =>
+      errors += errorAt(param.source, s"Duplicate given parameter: ${param.name}")
+    }
+    val givenParamNames = funDecl.givenParams.map(_.name).toSet
+    funDecl.params.filter(p => givenParamNames.contains(p.name)).foreach { param =>
+      errors += errorAt(param.source, s"Parameter shadows given: ${param.name}")
+    }
     val params = paramsWithSource.map(_._2)
+    val givens = givenWithSource.map(_._2)
+    val scopeBindings = (params ++ givens).map(p => p.name -> p).toMap
     val env =
-      TypeEnv(List(params.map(p => p.name -> p).toMap), exports, funDecl.typeParams.toSet, funSymbol.tpe.result)
+      TypeEnv(List(scopeBindings), exports, funDecl.typeParams.toSet, funSymbol.tpe.result, givens)
     val expectedBodyType =
       if funSymbol.tpe.result == Type.Unknown then None else Some(funSymbol.tpe.result)
     val (typedBody, bodyErrors) = typeSuite(funDecl.body, env, funSymbol.tpe.result, expectedBodyType, idSupply)
     errors ++= bodyErrors
-    val typedFun: TopLevel.FunDecl = TopLevel.FunDecl(funSymbol, funDecl.typeParams, params, typedBody)(funDecl.source)
+    val typedFun: TopLevel.FunDecl =
+      TopLevel.FunDecl(funSymbol, funDecl.typeParams, params, givens, typedBody)(funDecl.source)
     (typedFun, errors.toList)
+
+  def typeInstance(
+      instanceDecl: ast.TopLevel.InstanceDecl,
+      exports: ExportEnv
+    ): (TopLevel.InstanceDecl, List[TypeError]) =
+    val errors = ListBuffer.empty[TypeError]
+    val instanceDef = exports.instances.get(instanceDecl.name)
+    val idSupply = new IdSupply
+    errors ++= validateAstType(instanceDecl.head, instanceDecl.typeParams.toSet, exports)
+    val headType = fromAstType(instanceDecl.head)
+    instanceDecl.givenParams.foreach { param =>
+      errors ++= validateAstType(param.tpe, instanceDecl.typeParams.toSet, exports)
+    }
+    val (typeClassName, typeClassArgs) = headType match
+      case Type.App(Type.Name(tcName), args) => (tcName, args)
+      case Type.Name(tcName) => (tcName, Nil)
+      case _ => ("", Nil)
+    val typeClassDefOpt = exports.typeClasses.get(typeClassName)
+    typeClassDefOpt match
+      case None =>
+        errors += errorAt(instanceDecl.source, s"Unknown typeclass: ${typeClassName}")
+      case Some(typeClassDef) =>
+        val duplicateMembers = instanceDecl.members.groupBy(_.name).collect { case (_, ms) if ms.length > 1 => ms }
+        duplicateMembers.flatten.foreach { member =>
+          errors += errorAt(member.source, s"Duplicate member ${member.name} in instance ${instanceDecl.name}")
+        }
+        if typeClassDef.typeParams.length != typeClassArgs.length then
+          errors += errorAt(
+            instanceDecl.source,
+            s"Typeclass ${typeClassDef.name} expects ${typeClassDef.typeParams.length} type arguments, got ${typeClassArgs.length}"
+          )
+        val typeClassSubst = typeClassDef.typeParams.zip(typeClassArgs).toMap
+        val membersByName = instanceDecl.members.map(m => m.name -> m).toMap
+        typeClassDef.members.foreach { member =>
+          membersByName.get(member.name) match
+            case None =>
+              errors += errorAt(instanceDecl.source, s"Missing member ${member.name} in instance ${instanceDecl.name}")
+            case Some(funDecl) =>
+              val expectedParams = member.params.map(param => instantiateType(param, typeClassSubst))
+              val expectedResult = instantiateType(member.result, typeClassSubst)
+              if funDecl.params.length != expectedParams.length then
+                errors += errorAt(
+                  funDecl.source,
+                  s"Member ${member.name} expects ${expectedParams.length} parameters, got ${funDecl.params.length}"
+                )
+              funDecl.params.zip(expectedParams).foreach { case (param, expected) =>
+                val actual = fromAstType(param.tpe)
+                if !isCompatible(expected, actual) then
+                  errors += errorAt(
+                    param.source,
+                    s"Member ${member.name} parameter ${param.name} has type ${renderType(actual)}, expected ${renderType(expected)}"
+                  )
+              }
+              funDecl.returnType.foreach { actualReturn =>
+                val actual = fromAstType(actualReturn)
+                if !isCompatible(expectedResult, actual) then
+                  errors += errorAt(
+                    actualReturn.source,
+                    s"Member ${member.name} returns ${renderType(actual)}, expected ${renderType(expectedResult)}"
+                  )
+              }
+              if funDecl.returnType.isEmpty then
+                errors += errorAt(funDecl.source, s"Missing return type for member: ${member.name}")
+        }
+    val givenParams = instanceDecl.givenParams.map { param =>
+      ParamSymbol(param.name, fromAstType(param.tpe), idSupply.freshId())
+    }
+    val typedMembers = instanceDecl.members.flatMap { memberDecl =>
+      if memberDecl.givenParams.nonEmpty then
+        errors += errorAt(memberDecl.source, s"Member ${memberDecl.name} cannot declare its own given parameters")
+        None
+      else
+        val explicitParams = memberDecl.params.map { param =>
+          ParamSymbol(param.name, fromAstType(param.tpe), idSupply.freshId())
+        }
+        val duplicateParams = memberDecl.params.groupBy(_.name).collect { case (_, ps) if ps.length > 1 => ps }
+        duplicateParams.flatten.foreach { param =>
+          errors += errorAt(param.source, s"Duplicate parameter: ${param.name}")
+        }
+        val givenParamNames = givenParams.map(_.name).toSet
+        memberDecl.params.filter(p => givenParamNames.contains(p.name)).foreach { param =>
+          errors += errorAt(param.source, s"Parameter shadows instance given: ${param.name}")
+        }
+        val memberSymbol = instanceDef.flatMap(_.symbol.members.get(memberDecl.name)).getOrElse {
+          FunctionSymbol(s"${instanceDecl.name}.${memberDecl.name}", memberDecl.typeParams, Type.Fun(Nil, Type.Unknown), Nil)
+        }
+        val allParams = explicitParams ++ givenParams
+        val scopeBindings = allParams.map(p => p.name -> p).toMap
+        val env =
+          TypeEnv(List(scopeBindings), exports, (instanceDecl.typeParams ++ memberDecl.typeParams).toSet, memberSymbol.tpe.result, givenParams)
+        val expectedBodyType =
+          if memberSymbol.tpe.result == Type.Unknown then None else Some(memberSymbol.tpe.result)
+        val (typedBody, bodyErrors) = typeSuite(memberDecl.body, env, memberSymbol.tpe.result, expectedBodyType, idSupply)
+        errors ++= bodyErrors
+        Some(InstanceMember(memberDecl.name, memberSymbol, allParams, typedBody)(memberDecl.source))
+    }
+    val instanceSymbol = instanceDef.map(_.symbol).getOrElse(
+      InstanceSymbol(instanceDecl.name, instanceDecl.typeParams, headType, givenParams.map(_.tpe), Map.empty)
+    )
+    (TopLevel.InstanceDecl(instanceSymbol, instanceDecl.typeParams, givenParams, typedMembers)(instanceDecl.source), errors.toList)
 
   private def typeSuite(
       suite: ast.Suite,
@@ -243,7 +460,8 @@ object TypeChecker:
       case ast.Expr.Var(name) => synthVar(name, expr.source, env)
       case ast.Expr.Paren(inner) => synthParen(inner, expr.source, env, idSupply)
       case ast.Expr.Block(exprs) => synthBlock(exprs, expr.source, env, idSupply)
-      case ast.Expr.Call(callee, args) => synthCall(callee, args, expr.source, env, idSupply)
+      case ast.Expr.Call(callee, typeArgs, args, usingArgs) =>
+        synthCall(callee, typeArgs, args, usingArgs, expr.source, env, idSupply)
       case ast.Expr.LetIn(name, isConstant, declaredTypeAst, valueExpr, bodyExpr) =>
         synthLetIn(name, isConstant, declaredTypeAst, valueExpr, bodyExpr, expr.source, env, idSupply)
       case ast.Expr.Bind(name, isConstant, declaredTypeAst, valueExpr) =>
@@ -278,8 +496,8 @@ object TypeChecker:
       case ast.Expr.Paren(inner) => checkParen(inner, expectedType, expr.source, env, expectedReturn, idSupply)
       case ast.Expr.Block(exprs) =>
         checkBlock(exprs, expectedType, expr.source, env, expectedReturn, idSupply)
-      case ast.Expr.Call(callee, args) =>
-        checkCall(callee, args, expectedType, expr.source, env, expectedReturn, idSupply)
+      case ast.Expr.Call(callee, typeArgs, args, usingArgs) =>
+        checkCall(callee, typeArgs, args, usingArgs, expectedType, expr.source, env, expectedReturn, idSupply)
       case ast.Expr.LetIn(name, isConstant, declaredTypeAst, valueExpr, bodyExpr) =>
         checkLetIn(
           name,
@@ -442,80 +660,354 @@ object TypeChecker:
   // T-App: Γ ⊢ f ⇒ T1 → T2  and  Γ ⊢ a ⇐ T1  ⇒  Γ ⊢ f a ⇒ T2
   private def synthCall(
       callee: ast.Expr,
+      typeArgs: List[ast.Type],
       args: List[ast.Expr],
+      usingArgs: List[ast.Expr],
       source: ast.SourceRange,
       env: TypeEnv,
       idSupply: IdSupply
     ): (Expr, List[TypeError]) =
-    checkCall(callee, args, Type.Unknown, source, env, env.expectedReturn, idSupply)
+    checkCall(callee, typeArgs, args, usingArgs, Type.Unknown, source, env, env.expectedReturn, idSupply)
 
   // T-App-Check: Γ ⊢ f ⇒ T1 → T2  and  Γ ⊢ a ⇐ T1  and  T2 ≈ T  ⇒  Γ ⊢ f a ⇐ T
   private def checkCall(
       callee: ast.Expr,
+      typeArgs: List[ast.Type],
       args: List[ast.Expr],
+      usingArgs: List[ast.Expr],
       expectedType: Type,
       source: ast.SourceRange,
       env: TypeEnv,
       expectedReturn: Type,
       idSupply: IdSupply
     ): (Expr, List[TypeError]) =
-    val (typedCallee, calleeErrors) = synthesizeExpr(callee, env, idSupply)
-    typedCallee match
-      case Expr.Var(symbol, _) if symbol.name == "." && args.length == 2 =>
-        val (typedArgs, argsErrors) = typeExprs(args, env, expectedReturn, None, idSupply)
-        val errors = calleeErrors ++ argsErrors :+ errorAt(callee.source, "Field access typing is not implemented")
-        (Expr.CallFun(typedCallee, typedArgs, Type.Unknown)(source), errors)
-      case Expr.Var(symbol, _) if symbol.name == "-" && args.length == 1 =>
-        val (typedArg, argErrors) = checkExpr(args.head, env, expectedReturn, baseTypes("Int"), idSupply)
-        val errors = calleeErrors ++ argErrors
-        (Expr.CallFun(typedCallee, List(typedArg), baseTypes("Int"))(source), errors)
-      case Expr.Var(symbol: CtorSymbol, _) =>
-        val (typedExpr, ctorErrors) = typeCtorCall(symbol, args, expectedType, source, env, expectedReturn, idSupply)
-        (typedExpr, calleeErrors ++ ctorErrors)
+    callee match
+      case ast.Expr.Var(name) if env.exports.memberIndex.contains(name) =>
+        typeClassMemberCall(name, typeArgs, args, usingArgs, expectedType, source, env, expectedReturn, idSupply)
       case _ =>
-        val maybeFunType = resolveFunctionType(typedCallee)
-        maybeFunType match
-          case Some((funType, typeParams)) =>
-            val errors = ListBuffer.empty[TypeError]
-            errors ++= calleeErrors
-            val typeParamBindings = scala.collection.mutable.Map.empty[String, Type]
-            if expectedType != Type.Unknown then
-              collectTypeParamBindings(funType.result, expectedType, typeParams, typeParamBindings)
-            val typedArgs = args.zipWithIndex.map { case (arg, index) =>
-              val expectedParamType =
-                if index < funType.params.length then
-                  instantiateType(funType.params(index), typeParamBindings.toMap)
-                else Type.Unknown
-              val (typedArg, argErrors) = checkExpr(arg, env, expectedReturn, expectedParamType, idSupply)
-              errors ++= argErrors
-              if index < funType.params.length then
-                collectTypeParamBindings(funType.params(index), typedArg.tpe, typeParams, typeParamBindings)
-              typedArg
-            }
-            val instantiatedParamTypes = funType.params.map(p => instantiateType(p, typeParamBindings.toMap))
-            val instantiatedResultType = instantiateType(funType.result, typeParamBindings.toMap)
-            if instantiatedParamTypes.length != args.length then
-              errors += errorAt(callee.source, s"Call expects ${instantiatedParamTypes.length} args, got ${args.length}")
-            instantiatedParamTypes.zipAll(
-              typedArgs,
-              Type.Unknown,
-              Expr.Var(ErrorSymbol("<missing>", Type.Unknown), Type.Unknown)(callee.source)
-            ).foreach {
-              case (expected, actual) if !isCompatible(expected, actual.tpe) =>
-                errors += errorAt(
-                  actual.source,
-                  s"Argument has type ${renderType(actual.tpe)}, expected ${renderType(expected)}"
-                )
-              case _ => ()
-            }
-            val (checkedType, expectedErrors) = ensureExpectedType(instantiatedResultType, Some(expectedType), source)
-            errors ++= expectedErrors
-            (Expr.CallFun(typedCallee, typedArgs, checkedType)(source), errors.toList)
-          case None =>
+        val (typedCallee, calleeErrors) = synthesizeExpr(callee, env, idSupply)
+        typedCallee match
+          case Expr.Var(symbol, _) if symbol.name == "." && args.length == 2 =>
             val (typedArgs, argsErrors) = typeExprs(args, env, expectedReturn, None, idSupply)
-            val errors =
-              calleeErrors ++ argsErrors :+ errorAt(callee.source, s"Call target is not a function: ${renderType(typedCallee.tpe)}")
-            (Expr.CallFun(typedCallee, typedArgs, Type.Unknown)(source), errors)
+            val errors = calleeErrors ++ argsErrors :+ errorAt(callee.source, "Field access typing is not implemented")
+            (Expr.CallFun(typedCallee, typedArgs, Nil, Type.Unknown)(source), errors)
+          case Expr.Var(symbol, _) if symbol.name == "-" && args.length == 1 =>
+            val (typedArg, argErrors) = checkExpr(args.head, env, expectedReturn, baseTypes("Int"), idSupply)
+            val errors = calleeErrors ++ argErrors
+            (Expr.CallFun(typedCallee, List(typedArg), Nil, baseTypes("Int"))(source), errors)
+          case Expr.Var(symbol: CtorSymbol, _) =>
+            val (typedExpr, ctorErrors) = typeCtorCall(symbol, args, expectedType, source, env, expectedReturn, idSupply)
+            (typedExpr, calleeErrors ++ ctorErrors)
+          case _ =>
+            val maybeFunType = resolveFunctionType(typedCallee)
+            maybeFunType match
+              case Some((funType, typeParams, givenTypes)) =>
+                val errors = ListBuffer.empty[TypeError]
+                errors ++= calleeErrors
+                val typeParamBindings = scala.collection.mutable.Map.empty[String, Type]
+                val explicitBindings = explicitTypeArgs(typeParams, typeArgs, source, errors)
+                typeParamBindings ++= explicitBindings
+                if expectedType != Type.Unknown then
+                  collectTypeParamBindings(funType.result, expectedType, typeParams.toSet, typeParamBindings)
+                val typedArgs = args.zipWithIndex.map { case (arg, index) =>
+                  val expectedParamType =
+                    if index < funType.params.length then
+                      relaxExpectedType(
+                        instantiateType(funType.params(index), typeParamBindings.toMap),
+                        typeParams.toSet,
+                        typeParamBindings
+                      )
+                    else Type.Unknown
+                  val (typedArg, argErrors) = checkExpr(arg, env, expectedReturn, expectedParamType, idSupply)
+                  errors ++= argErrors
+                  if index < funType.params.length then
+                    collectTypeParamBindings(funType.params(index), typedArg.tpe, typeParams.toSet, typeParamBindings)
+                  typedArg
+                }
+                val instantiatedParamTypes = funType.params.map(p => instantiateType(p, typeParamBindings.toMap))
+                val instantiatedResultType = instantiateType(funType.result, typeParamBindings.toMap)
+                if instantiatedParamTypes.length != args.length then
+                  errors += errorAt(callee.source, s"Call expects ${instantiatedParamTypes.length} args, got ${args.length}")
+                instantiatedParamTypes.zipAll(
+                  typedArgs,
+                  Type.Unknown,
+                  Expr.Var(ErrorSymbol("<missing>", Type.Unknown), Type.Unknown)(callee.source)
+                ).foreach {
+                  case (expected, actual) if !isCompatible(expected, actual.tpe) =>
+                    errors += errorAt(
+                      actual.source,
+                      s"Argument has type ${renderType(actual.tpe)}, expected ${renderType(expected)}"
+                    )
+                  case _ => ()
+                }
+                val (givenArgsResolved, givenErrors) =
+                  resolveGivenArguments(givenTypes, usingArgs, typeParamBindings, env, source, idSupply, Nil)
+                errors ++= givenErrors
+                val (checkedType, expectedErrors) = ensureExpectedType(instantiatedResultType, Some(expectedType), source)
+                errors ++= expectedErrors
+                (Expr.CallFun(typedCallee, typedArgs, givenArgsResolved, checkedType)(source), errors.toList)
+              case None =>
+                val (typedArgs, argsErrors) = typeExprs(args, env, expectedReturn, None, idSupply)
+                val errors =
+                  calleeErrors ++ argsErrors :+ errorAt(
+                    callee.source,
+                    s"Call target is not a function: ${renderType(typedCallee.tpe)}"
+                  )
+                (Expr.CallFun(typedCallee, typedArgs, Nil, Type.Unknown)(source), errors)
+
+  private def typeClassMemberCall(
+      name: String,
+      typeArgs: List[ast.Type],
+      args: List[ast.Expr],
+      usingArgs: List[ast.Expr],
+      expectedType: Type,
+      source: ast.SourceRange,
+      env: TypeEnv,
+      expectedReturn: Type,
+      idSupply: IdSupply
+    ): (Expr, List[TypeError]) =
+    val errors = ListBuffer.empty[TypeError]
+    if typeArgs.nonEmpty then
+      errors += errorAt(source, s"Type arguments are not supported for typeclass member calls: $name")
+    val candidates = env.exports.memberIndex.getOrElse(name, Nil).flatMap { tc =>
+      tc.members.find(_.name == name).map(member => (tc, member))
+    }
+    val typedCandidates = candidates.flatMap { case (tc, member) =>
+      val typeParams = (tc.typeParams ++ member.typeParams).toSet
+      val typeParamBindings = scala.collection.mutable.Map.empty[String, Type]
+      if expectedType != Type.Unknown then
+        collectTypeParamBindings(member.result, expectedType, typeParams, typeParamBindings)
+      val typedArgs = args.zipWithIndex.map { case (arg, index) =>
+        val rawExpectedParamType =
+          if index < member.params.length then
+            instantiateType(member.params(index), typeParamBindings.toMap)
+          else Type.Unknown
+        val expectedParamType = relaxExpectedType(rawExpectedParamType, typeParams, typeParamBindings)
+        val (typedArg, argErrors) = checkExpr(arg, env, expectedReturn, expectedParamType, idSupply)
+        errors ++= argErrors
+        if index < member.params.length then
+          collectTypeParamBindings(member.params(index), typedArg.tpe, typeParams, typeParamBindings)
+        typedArg
+      }
+      val instantiatedParamTypes = member.params.map(p => instantiateType(p, typeParamBindings.toMap))
+      if instantiatedParamTypes.length != args.length then
+        errors += errorAt(source, s"Call expects ${instantiatedParamTypes.length} args, got ${args.length}")
+      instantiatedParamTypes.zipAll(
+        typedArgs,
+        Type.Unknown,
+        Expr.Var(ErrorSymbol("<missing>", Type.Unknown), Type.Unknown)(source)
+      ).foreach {
+        case (expected, actual) if !isCompatible(expected, actual.tpe) =>
+          errors += errorAt(
+            actual.source,
+            s"Argument has type ${renderType(actual.tpe)}, expected ${renderType(expected)}"
+          )
+        case _ => ()
+      }
+      val instantiatedResultType = instantiateType(member.result, typeParamBindings.toMap)
+      val typeClassArgs = tc.typeParams.map { param =>
+        typeParamBindings.getOrElse(param, Type.Unknown)
+      }
+      val goal = if typeClassArgs.isEmpty then Type.Name(tc.name) else Type.App(Type.Name(tc.name), typeClassArgs)
+      val preferGiven =
+        usingArgs.isEmpty && typedArgs.exists { arg =>
+          arg.tpe match
+            case Type.Name(name) if env.typeParams.contains(name) => true
+            case _ => false
+        }
+      val (instanceArgs, instanceErrors) =
+        if preferGiven then
+          val matchingGivens = env.givens.filter(g => isCompatible(g.tpe, goal))
+          matchingGivens match
+            case param :: Nil => (List(Expr.Var(param, param.tpe)(source)), Nil)
+            case _ :: _ => (Nil, List(errorAt(source, s"Ambiguous given for ${renderType(goal)}")))
+            case Nil => resolveGivenArguments(List(goal), usingArgs, typeParamBindings, env, source, idSupply, Nil)
+        else
+          resolveGivenArguments(List(goal), usingArgs, typeParamBindings, env, source, idSupply, Nil)
+      errors ++= instanceErrors
+      instanceArgs.headOption.map { instanceExpr =>
+        val (checkedType, expectedErrors) = ensureExpectedType(instantiatedResultType, Some(expectedType), source)
+        errors ++= expectedErrors
+        Expr.CallTypeClassMember(instanceExpr, name, typedArgs, checkedType)(source)
+      }
+    }
+    typedCandidates.distinct match
+      case Nil =>
+        val missingSymbol = ErrorSymbol(name, Type.Unknown)
+        val baseErrors =
+          if candidates.isEmpty || errors.isEmpty then
+            errors.toList :+ errorAt(source, s"No typeclass member found: $name")
+          else
+            errors.toList
+        (Expr.Var(missingSymbol, Type.Unknown)(source), baseErrors)
+      case expr :: Nil =>
+        (expr, errors.toList)
+      case _ =>
+        val missingSymbol = ErrorSymbol(name, Type.Unknown)
+        (
+          Expr.Var(missingSymbol, Type.Unknown)(source),
+          errors.toList :+ errorAt(source, s"Ambiguous typeclass member call: $name")
+        )
+
+  private def explicitTypeArgs(
+      typeParams: List[String],
+      typeArgs: List[ast.Type],
+      source: ast.SourceRange,
+      errors: ListBuffer[TypeError]
+    ): Map[String, Type] =
+    if typeArgs.isEmpty then
+      Map.empty
+    else
+      if typeParams.length != typeArgs.length then
+        errors += errorAt(source, s"Expected ${typeParams.length} type arguments, got ${typeArgs.length}")
+        Map.empty
+      else
+        typeParams.zip(typeArgs.map(fromAstType)).toMap
+
+  private def resolveGivenArguments(
+      givenTypes: List[Type],
+      usingArgs: List[ast.Expr],
+      typeParamBindings: scala.collection.mutable.Map[String, Type],
+      env: TypeEnv,
+      source: ast.SourceRange,
+      idSupply: IdSupply,
+      stack: List[Type]
+    ): (List[Expr], List[TypeError]) =
+    val errors = ListBuffer.empty[TypeError]
+    if usingArgs.nonEmpty && usingArgs.length != givenTypes.length then
+      errors += errorAt(source, s"Expected ${givenTypes.length} using arguments, got ${usingArgs.length}")
+    val resolved = givenTypes.zipWithIndex.flatMap { case (givenType, index) =>
+      val instantiatedGoal = instantiateType(givenType, typeParamBindings.toMap)
+      val (exprOpt, exprErrors) =
+        if usingArgs.nonEmpty && index < usingArgs.length then
+          resolveUsingExpr(usingArgs(index), instantiatedGoal, env, source, idSupply)
+        else
+          resolveInstance(instantiatedGoal, env, source, idSupply, stack, None)
+      errors ++= exprErrors
+      exprOpt.foreach(expr => collectTypeParamBindings(instantiatedGoal, expr.tpe, env.typeParams, typeParamBindings))
+      exprOpt
+    }
+    (resolved, errors.toList)
+
+  private def resolveUsingExpr(
+      usingExpr: ast.Expr,
+      goal: Type,
+      env: TypeEnv,
+      source: ast.SourceRange,
+      idSupply: IdSupply
+    ): (Option[Expr], List[TypeError]) =
+    usingExpr match
+      case ast.Expr.Var(name) =>
+        resolveSymbol(name, env) match
+          case Some(instanceSymbol: InstanceSymbol) =>
+            env.exports.instances.get(instanceSymbol.name) match
+              case Some(instance) => resolveNamedInstance(instance, goal, env, source, idSupply)
+              case None => (None, List(errorAt(source, s"Unknown using argument: $name")))
+          case _ =>
+            val (typedExpr, exprErrors) = checkExpr(usingExpr, env, env.expectedReturn, goal, idSupply)
+            (Some(typedExpr), exprErrors)
+      case _ =>
+        val (typedExpr, exprErrors) = checkExpr(usingExpr, env, env.expectedReturn, goal, idSupply)
+        (Some(typedExpr), exprErrors)
+
+  private def resolveNamedInstance(
+      instance: InstanceDef,
+      goal: Type,
+      env: TypeEnv,
+      source: ast.SourceRange,
+      idSupply: IdSupply
+    ): (Option[Expr], List[TypeError]) =
+    val (bindingsOpt, matchErrors) = matchInstance(instance, goal, source)
+    bindingsOpt match
+      case None => (None, matchErrors)
+      case Some((bindings, instantiatedHead)) =>
+        val prunedBindings = dropSelfBindings(bindings)
+        val (givenArgs, givenErrors) =
+          resolveGivenArguments(
+            instance.givenTypes.map(tpe => instantiateType(tpe, prunedBindings)),
+            Nil,
+            scala.collection.mutable.Map.empty,
+            env,
+            source,
+            idSupply,
+            goal :: Nil
+          )
+        val expr = Expr.InstanceValue(instance.symbol, givenArgs, instantiatedHead)(source)
+        (Some(expr), matchErrors ++ givenErrors)
+
+  private def resolveInstance(
+      goal: Type,
+      env: TypeEnv,
+      source: ast.SourceRange,
+      idSupply: IdSupply,
+      stack: List[Type],
+      filter: Option[Type]
+    ): (Option[Expr], List[TypeError]) =
+    if stack.exists(t => t == goal) then
+      (None, List(errorAt(source, s"Cyclic instance resolution for ${renderType(goal)}")))
+    else
+      val errors = ListBuffer.empty[TypeError]
+      val givenMatches = env.givens.filter(g => isCompatible(g.tpe, goal))
+      val filteredGiven = filter match
+        case Some(f) => givenMatches.filter(g => isCompatible(g.tpe, f))
+        case None => givenMatches
+      filteredGiven match
+        case param :: Nil =>
+          return (Some(Expr.Var(param, param.tpe)(source)), Nil)
+        case _ :: _ =>
+          return (None, List(errorAt(source, s"Ambiguous given for ${renderType(goal)}")))
+        case Nil => ()
+      val instanceCandidates = env.exports.instances.values.toList.filter { inst =>
+        filter.forall(f => isCompatible(inst.head, f)) && matchInstanceHead(inst, goal)
+      }
+      val resolved = instanceCandidates.flatMap { inst =>
+        val (bindingsOpt, matchErrors) = matchInstance(inst, goal, source)
+        bindingsOpt.flatMap { case (bindings, instantiatedHead) =>
+          val prunedBindings = dropSelfBindings(bindings)
+          val (givenArgs, givenErrors) =
+            resolveGivenArguments(
+              inst.givenTypes.map(tpe => instantiateType(tpe, prunedBindings)),
+              Nil,
+              scala.collection.mutable.Map.empty,
+              env,
+              source,
+              idSupply,
+              goal :: stack
+            )
+          if givenErrors.nonEmpty then
+            errors ++= matchErrors ++ givenErrors
+            None
+          else
+            Some((Expr.InstanceValue(inst.symbol, givenArgs, instantiatedHead)(source), matchErrors))
+        }
+      }
+      resolved match
+        case (expr, exprErrors) :: Nil =>
+          errors ++= exprErrors
+          (Some(expr), errors.toList)
+        case Nil =>
+          (None, List(errorAt(source, s"No instance found for ${renderType(goal)}")))
+        case _ =>
+          (None, List(errorAt(source, s"Ambiguous instance for ${renderType(goal)}")))
+
+  private def matchInstanceHead(instance: InstanceDef, goal: Type): Boolean =
+    val typeParamBindings = scala.collection.mutable.Map.empty[String, Type]
+    collectTypeParamBindings(instance.head, goal, instance.typeParams.toSet, typeParamBindings)
+    val instantiatedHead = instantiateType(instance.head, typeParamBindings.toMap)
+    isCompatible(instantiatedHead, goal)
+
+  private def matchInstance(
+      instance: InstanceDef,
+      goal: Type,
+      source: ast.SourceRange
+    ): (Option[(Map[String, Type], Type)], List[TypeError]) =
+    val typeParamBindings = scala.collection.mutable.Map.empty[String, Type]
+    collectTypeParamBindings(instance.head, goal, instance.typeParams.toSet, typeParamBindings)
+    val instantiatedHead = instantiateType(instance.head, typeParamBindings.toMap)
+    if isCompatible(instantiatedHead, goal) then
+      (Some(typeParamBindings.toMap -> instantiatedHead), Nil)
+    else
+      (None, List(errorAt(source, s"Instance ${instance.symbol.name} does not match ${renderType(goal)}")))
 
   private def typeCtorCall(
       ctor: CtorSymbol,
@@ -532,10 +1024,13 @@ object TypeChecker:
     if expectedType != Type.Unknown then
       collectTypeParamBindings(resultType, expectedType, ctor.typeParams.toSet, typeParamBindings)
     val typedArgs = args.zipWithIndex.map { case (arg, index) =>
-      val expectedParamType =
+      val rawExpectedParamType =
         if index < paramTypes.length then
           instantiateType(paramTypes(index), typeParamBindings.toMap)
         else Type.Unknown
+      val expectedParamType = rawExpectedParamType match
+        case Type.Name(name) if ctor.typeParams.contains(name) => Type.Unknown
+        case other => other
       val (typedArg, argErrors) = checkExpr(arg, env, expectedReturn, expectedParamType, idSupply)
       errors ++= argErrors
       if index < paramTypes.length then
@@ -1032,6 +1527,26 @@ object TypeChecker:
         collectTypeParamBindings(patternResult, actualResult, typeParams, bindings)
       case _ => ()
 
+  private def relaxExpectedType(
+      tpe: Type,
+      typeParams: Set[String],
+      bindings: scala.collection.mutable.Map[String, Type]
+    ): Type =
+    tpe match
+      case Type.Name(name) if typeParams.contains(name) =>
+        bindings.get(name) match
+          case None => Type.Unknown
+          case Some(bound) if bound == Type.Name(name) => Type.Unknown
+          case _ => tpe
+      case Type.App(base, args) =>
+        Type.App(relaxExpectedType(base, typeParams, bindings), args.map(relaxExpectedType(_, typeParams, bindings)))
+      case Type.Fun(params, result) =>
+        Type.Fun(
+          params.map(relaxExpectedType(_, typeParams, bindings)),
+          relaxExpectedType(result, typeParams, bindings)
+        )
+      case other => other
+
   private def instantiateType(tpe: Type, bindings: Map[String, Type]): Type =
     tpe match
       case Type.Name(name) => bindings.getOrElse(name, tpe)
@@ -1039,6 +1554,17 @@ object TypeChecker:
       case Type.Fun(params, result) =>
         Type.Fun(params.map(instantiateType(_, bindings)), instantiateType(result, bindings))
       case Type.Unknown => Type.Unknown
+
+  private def dropSelfBindings(bindings: Map[String, Type]): Map[String, Type] =
+    bindings.filterNot { case (name, tpe) => containsTypeParam(tpe, name) }
+
+  private def containsTypeParam(tpe: Type, name: String): Boolean =
+    tpe match
+      case Type.Name(value) => value == name
+      case Type.App(base, args) => containsTypeParam(base, name) || args.exists(containsTypeParam(_, name))
+      case Type.Fun(params, result) =>
+        params.exists(containsTypeParam(_, name)) || containsTypeParam(result, name)
+      case Type.Unknown => false
 
   private def iterableElementType(tpe: Type, source: ast.SourceRange): (Type, List[TypeError]) =
     tpe match
@@ -1093,16 +1619,16 @@ object TypeChecker:
       case None =>
         (actualType, Nil)
 
-  private def resolveFunctionType(callee: Expr): Option[(Type.Fun, Set[String])] =
+  private def resolveFunctionType(callee: Expr): Option[(Type.Fun, List[String], List[Type])] =
     callee match
       case Expr.Var(symbol, _) =>
         symbol match
-          case fun: FunctionSymbol => Some((fun.tpe, fun.typeParams.toSet))
-          case builtin: BuiltinFunctionSymbol => Some((builtin.tpe, Set.empty[String]))
+          case fun: FunctionSymbol => Some((fun.tpe, fun.typeParams, fun.givenParams))
+          case builtin: BuiltinFunctionSymbol => Some((builtin.tpe, Nil, Nil))
           case _ => None
       case _ =>
         callee.tpe match
-          case tpe: Type.Fun => Some((tpe, Set.empty[String]))
+          case tpe: Type.Fun => Some((tpe, Nil, Nil))
           case _ => None
 
   private def isCompatible(expected: Type, actual: Type): Boolean =
@@ -1112,9 +1638,12 @@ object TypeChecker:
       case _ => expected == actual
 
   private def resolveSymbol(name: String, env: TypeEnv): Option[Symbol] =
-    env.resolveLocal(name).orElse(baseValues.get(name)).orElse(env.exports.functions.get(name)).orElse(
-      env.exports.ctors.get(name)
-    ).orElse(baseFunctions.get(name))
+    env.resolveLocal(name)
+      .orElse(baseValues.get(name))
+      .orElse(env.exports.instances.get(name).map(_.symbol))
+      .orElse(env.exports.functions.get(name))
+      .orElse(env.exports.ctors.get(name))
+      .orElse(baseFunctions.get(name))
 
   private def fromAstType(tpe: ast.Type): Type =
     tpe match
@@ -1125,12 +1654,28 @@ object TypeChecker:
   private def validateAstType(tpe: ast.Type, typeParams: Set[String], exports: ExportEnv): List[TypeError] =
     tpe match
       case ast.Type.Name(value) =>
-        if typeParams.contains(value) || builtinTypeNames.contains(value) || exports.types.contains(value) then Nil
+        if typeParams.contains(value) || builtinTypeNames.contains(value) || exports.types.contains(value) || exports.typeClasses.contains(value) then Nil
         else List(errorAt(tpe.source, s"Unknown type name: $value"))
       case ast.Type.App(base, args) =>
         validateAstType(base, typeParams, exports) ++ args.flatMap(arg => validateAstType(arg, typeParams, exports))
       case ast.Type.Paren(inner) =>
         validateAstType(inner, typeParams, exports)
+
+  private def validateTypedType(
+      tpe: Type,
+      typeParams: Set[String],
+      exports: ExportEnv,
+      source: ast.SourceRange
+    ): List[TypeError] =
+    tpe match
+      case Type.Name(value) =>
+        if typeParams.contains(value) || builtinTypeNames.contains(value) || exports.types.contains(value) || exports.typeClasses.contains(value) then Nil
+        else List(errorAt(source, s"Unknown type name: $value"))
+      case Type.App(base, args) =>
+        validateTypedType(base, typeParams, exports, source) ++ args.flatMap(arg => validateTypedType(arg, typeParams, exports, source))
+      case Type.Fun(params, result) =>
+        params.flatMap(param => validateTypedType(param, typeParams, exports, source)) ++ validateTypedType(result, typeParams, exports, source)
+      case Type.Unknown => Nil
 
   private def literalType(literal: ast.Literal): Type =
     literal match

--- a/src/main/scala/com/github/peterzeller/minifumo/typing/TypedAst.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/typing/TypedAst.scala
@@ -18,10 +18,18 @@ object TypedAst:
 
   final case class LocalSymbol(name: String, tpe: Type, id: Int) extends TermSymbol
   final case class ParamSymbol(name: String, tpe: Type, id: Int) extends TermSymbol
+  final case class InstanceSymbol(
+      name: String,
+      typeParams: List[String],
+      headType: Type,
+      givenParams: List[Type],
+      members: Map[String, FunctionSymbol]
+    ) extends TermSymbol:
+    override def tpe: Type = headType
   final case class BuiltinValueSymbol(name: String, tpe: Type) extends TermSymbol
   final case class ErrorSymbol(name: String, tpe: Type) extends Symbol
 
-  final case class FunctionSymbol(name: String, typeParams: List[String], tpe: Type.Fun) extends Symbol
+  final case class FunctionSymbol(name: String, typeParams: List[String], tpe: Type.Fun, givenParams: List[Type]) extends Symbol
   final case class CtorSymbol(name: String, typeParams: List[String], tpe: Type.Fun, arity: Int, resultType: Type)
       extends Symbol
   final case class BuiltinFunctionSymbol(name: String, tpe: Type.Fun) extends Symbol
@@ -30,7 +38,38 @@ object TypedAst:
 
   enum TopLevel:
     case DataDecl(name: String, typeParams: List[String], ctors: List[CtorDecl])(val source: SourceRange)
-    case FunDecl(symbol: FunctionSymbol, typeParams: List[String], params: List[ParamSymbol], body: Suite)(val source: SourceRange)
+    case FunDecl(
+        symbol: FunctionSymbol,
+        typeParams: List[String],
+        params: List[ParamSymbol],
+        givenParams: List[ParamSymbol],
+        body: Suite
+      )(val source: SourceRange)
+    case TypeClassDecl(
+        name: String,
+        typeParams: List[String],
+        members: List[TypeClassMember]
+      )(val source: SourceRange)
+    case InstanceDecl(
+        symbol: InstanceSymbol,
+        typeParams: List[String],
+        givenParams: List[ParamSymbol],
+        members: List[InstanceMember]
+      )(val source: SourceRange)
+
+  final case class TypeClassMember(
+      name: String,
+      typeParams: List[String],
+      params: List[Type],
+      result: Type
+    )(val source: SourceRange)
+
+  final case class InstanceMember(
+      memberName: String,
+      symbol: FunctionSymbol,
+      params: List[ParamSymbol],
+      body: Suite
+    )(val source: SourceRange)
 
   final case class CtorDecl(symbol: CtorSymbol, fields: List[CtorField])(val source: SourceRange)
   final case class CtorField(name: String, tpe: Type)(val source: SourceRange)
@@ -48,8 +87,13 @@ object TypedAst:
     final case class Var(symbol: Symbol, tpe: Type)(val source: SourceRange) extends Expr
     final case class Paren(expr: Expr, tpe: Type)(val source: SourceRange) extends Expr
     final case class Block(exprs: List[Expr], tpe: Type)(val source: SourceRange) extends Expr
-    final case class CallFun(callee: Expr, args: List[Expr], tpe: Type)(val source: SourceRange) extends Expr
+    final case class CallFun(callee: Expr, args: List[Expr], givenArgs: List[Expr], tpe: Type)(val source: SourceRange)
+        extends Expr
     final case class CallCtor(symbol: CtorSymbol, args: List[Expr], tpe: Type)(val source: SourceRange) extends Expr
+    final case class InstanceValue(symbol: InstanceSymbol, givenArgs: List[Expr], tpe: Type)(val source: SourceRange) extends Expr
+    final case class CallTypeClassMember(instance: Expr, memberName: String, args: List[Expr], tpe: Type)(
+        val source: SourceRange
+      ) extends Expr
     final case class LetIn(
         symbol: LocalSymbol,
         isConstant: Boolean,

--- a/src/test/scala/ExamplesSuite.scala
+++ b/src/test/scala/ExamplesSuite.scala
@@ -38,7 +38,11 @@ class ExamplesSuite extends FunSuite:
 
   for file <- exampleFiles do
     test(s"run example ${file.getFileName}"):
-      val expectedErrors = extractExpectedErrors(Files.readString(file))
+      val content = Files.readString(file)
+      val expectedErrors = extractExpectedErrors(content)
+      val expectedOutputOpt = extractExpectedOutput(content)
+      if expectedErrors.isEmpty && expectedOutputOpt.isEmpty then
+        fail(s"Example ${file.getFileName} must declare expected output or expected errors.")
       val actualErrors = collectErrors(file)
       if expectedErrors.isEmpty && actualErrors.isEmpty then
         runExample(file)


### PR DESCRIPTION
### Motivation
- Restore example fixtures that were previously modified and address failing example tests caused by incorrect typeclass handling.  
- Enable correct typeclass/given resolution so generic instances (e.g. `Ord[MyList[T]]`) work and do not recurse into self-bindings.  
- Improve call/type-argument handling to better guide inference for generic and typeclass member calls.

### Description
- Restored original example files `doc/examples/expr_while.minifumo` and `doc/examples/imperative_while_loop.minifumo` to their original structure.  
- Reworked the `Ord` example `doc/examples/typeclasses_ord.minifumo` to use a generic `instance ordList[T] for Ord[MyList[T]] given (o Ord[T])` and removed unnecessary explicit type arguments at call sites.  
- Added typeclass and instance machinery to the AST/typing pipeline, including `TypeClassDef`, `TypeClassMemberSig`, `InstanceDef`, `InstanceSymbol`, and updates to `ExportEnv`, `TypedAst`, `AstTransform`, and parser (`using`/`usingClause`) to support `given` arguments, instance declarations, and typeclass members.  
- Implemented instance/given resolution improvements in `TypeChecker.scala`: added `explicitTypeArgs`, `relaxExpectedType` (to avoid over-constraining unbound type params), `resolveGivenArguments`, `resolveNamedInstance`, `resolveInstance`, `matchInstance`/`matchInstanceHead`, and `dropSelfBindings`/`containsTypeParam` to prune self-referential bindings when resolving givens.  
- Updated call typing (`checkCall`/`synthCall`) to thread type arguments and `using` (given) arguments, and prefer compatible givens when appropriate.  
- Extended the interpreter (`Interpreter.scala`) to represent runtime instance values (`InstanceVal`) and to evaluate instance construction and typeclass member calls with captured given arguments.  

### Testing
- Ran the full automated test suite with `./sbt/bin/sbt test`, which completed successfully: `Passed: Total 49, Failed 0, Errors 0, Passed 49`.
- Tests were run iteratively while debugging instance resolution and runtime invocation; final automated run passed all tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976467b84048324b6a77d2cfb682889)