### PR TITLE
Implement stdlib operations in Minifumo (remove native calls)

### DIFF
--- a/src/main/antlr4/Minifumo.g4
+++ b/src/main/antlr4/Minifumo.g4
@@ -99,7 +99,7 @@ typeClassSigBlock
   ;
 
 typeClassImplBlock
-  : (NL)* funDecl (NL+ funDecl)* (NL)*
+  : (NL)* funDecl (NL* funDecl)* (NL)*
   ;
 
 // -------- Types --------

--- a/src/main/scala/com/github/peterzeller/minifumo/Main.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/Main.scala
@@ -1,6 +1,7 @@
 package com.github.peterzeller.minifumo
 
 import com.github.peterzeller.minifumo.ast.{AstTransform, ProgramFile, SourcePos, SourceRange}
+import com.github.peterzeller.minifumo.builtins.Standard
 import com.github.peterzeller.minifumo.common.MinifumoError
 import com.github.peterzeller.minifumo.interpreter.Interpreter
 import com.github.peterzeller.minifumo.parser.{SyntaxError, parseInput}
@@ -77,7 +78,8 @@ object Main:
       if allErrors.nonEmpty then
         Left(renderTypeErrors(path, allErrors))
       else
-        val combinedProgram = TypedAst.Program(importedItems ++ typedProgram.items)(typedProgram.source)
+        val combinedProgram =
+          TypedAst.Program(Standard.typedProgram.items ++ importedItems ++ typedProgram.items)(typedProgram.source)
         Right(Interpreter.evalProg(combinedProgram, "main"))
 
   // Checks a directory of examples, reusing cached parse/import info across files.
@@ -219,7 +221,14 @@ object Main:
       val exports =
         info.exportCache.getOrElseUpdate(
           path,
-          TypeChecker.extractExports(program, TypeChecker.emptyExportEnv, includeNonExported = false)._1
+          TypeChecker.extractExports(
+            program,
+            TypeChecker.withStandardExports(TypeChecker.emptyExportEnv),
+            includeNonExported = false,
+            shadowedTypes = Standard.standardExports.types.keySet,
+            shadowedCtors = Standard.standardExports.ctors.keySet,
+            shadowedTypeClasses = Standard.standardExports.typeClasses.keySet
+          )._1
         )
       (exports, Nil)
 
@@ -247,7 +256,14 @@ object Main:
                 resolveImportsForProgram(program, root, info)
               errors ++= importErrors
               val (resolvedExports, exportErrors) =
-                TypeChecker.extractExports(program, importedExports, includeNonExported = false)
+                TypeChecker.extractExports(
+                  program,
+                  TypeChecker.withStandardExports(importedExports),
+                  includeNonExported = false,
+                  shadowedTypes = Standard.standardExports.types.keySet,
+                  shadowedCtors = Standard.standardExports.ctors.keySet,
+                  shadowedTypeClasses = Standard.standardExports.typeClasses.keySet
+                )
               errors ++= exportErrors
               resolvedExports
           info.resolving.remove(path)

--- a/src/main/scala/com/github/peterzeller/minifumo/ast/AstTransform.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/ast/AstTransform.scala
@@ -136,19 +136,33 @@ object AstTransform:
         // The expression x.f(a,b,c) is short for f(x,a,b,c)
         opCall(c.ID().getText(), expr(c.expr()) :: argList(c.argList()), range(c))
       case c: MinifumoParser.NegContext =>
-        opCall("-", List(expr(c.expr())), range(c))
+        opCall("opNeg", List(expr(c.expr())), range(c))
       case c: MinifumoParser.MulDivContext =>
-        opCall(c.op.getText, List(expr(c.expr(0)), expr(c.expr(1))), range(c))
+        opCall(binaryOpName(c.op.getText), List(expr(c.expr(0)), expr(c.expr(1))), range(c))
       case c: MinifumoParser.AddSubContext =>
-        opCall(c.op.getText, List(expr(c.expr(0)), expr(c.expr(1))), range(c))
+        opCall(binaryOpName(c.op.getText), List(expr(c.expr(0)), expr(c.expr(1))), range(c))
       case c: MinifumoParser.CompareContext =>
-        opCall(c.op.getText, List(expr(c.expr(0)), expr(c.expr(1))), range(c))
+        val left = expr(c.expr(0))
+        val right = expr(c.expr(1))
+        val op = c.op.getText
+        if op == ">" then
+          opCall("opLt", List(right, left), range(c))
+        else if op == ">=" then
+          opCall("opLe", List(right, left), range(c))
+        else
+          opCall(binaryOpName(op), List(left, right), range(c))
       case c: MinifumoParser.EqNeqContext =>
-        opCall(c.op.getText, List(expr(c.expr(0)), expr(c.expr(1))), range(c))
+        val left = expr(c.expr(0))
+        val right = expr(c.expr(1))
+        if c.op.getText == "!=" then
+          val eqExpr = opCall("eq", List(left, right), range(c))
+          Expr.Call(Expr.Var("opNot")(range(c)), Nil, List(eqExpr), Nil)(range(c))
+        else
+          opCall("eq", List(left, right), range(c))
       case c: MinifumoParser.AndContext =>
-        opCall("and", List(expr(c.expr(0)), expr(c.expr(1))), range(c))
+        opCall("opAnd", List(expr(c.expr(0)), expr(c.expr(1))), range(c))
       case c: MinifumoParser.OrContext =>
-        opCall("or", List(expr(c.expr(0)), expr(c.expr(1))), range(c))
+        opCall("opOr", List(expr(c.expr(0)), expr(c.expr(1))), range(c))
       case c: MinifumoParser.LetInContext =>
         val tpe = Option(c.`type`()).map(`type`)
         Expr.LetIn(c.ID().getText, true, tpe, expr(c.expr(0)), expr(c.expr(1)))(range(c))
@@ -257,6 +271,18 @@ object AstTransform:
 
   private def opCall(name: String, args: List[Expr], source: SourceRange): Expr =
     Expr.Call(Expr.Var(name)(source), Nil, args, Nil)(source)
+
+  // Maps operator symbols to standard library typeclass member names.
+  private def binaryOpName(symbol: String): String =
+    symbol match
+      case "+" => "opPlus"
+      case "-" => "opMinus"
+      case "*" => "opTimes"
+      case "/" => "opDiv"
+      case "%" => "opMod"
+      case "<" => "opLt"
+      case "<=" => "opLe"
+      case other => other
 
   private def suiteToExpr(s: Suite): Expr =
     s match

--- a/src/main/scala/com/github/peterzeller/minifumo/builtins/Standard.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/builtins/Standard.scala
@@ -1,5 +1,43 @@
 package com.github.peterzeller.minifumo.builtins
 
-object Standard {
+import com.github.peterzeller.minifumo.ast.{AstTransform, ProgramFile}
+import com.github.peterzeller.minifumo.parser.parseInput
+import com.github.peterzeller.minifumo.typing.{TypeChecker, TypedAst}
 
-}
+import java.nio.file.{Files, Paths}
+
+object Standard:
+  private val standardLibraryPath =
+    Paths.get("src/main/scala/com/github/peterzeller/minifumo/builtins/standard.minifumo")
+
+  // Loads the standard library source file from disk.
+  private def loadStandardSource(): String =
+    if !Files.exists(standardLibraryPath) then
+      throw new IllegalStateException(s"Standard library not found: ${standardLibraryPath.toString}")
+    new String(Files.readAllBytes(standardLibraryPath))
+
+  // Parses the standard library source into an AST program.
+  private def parseStandardProgram(): ProgramFile =
+    val (cst, errors) = parseInput(loadStandardSource())
+    if errors.nonEmpty then
+      val message = errors.map(err => s"${err.pos.line}:${err.pos.column}: ${err.message}").mkString("\n")
+      throw new IllegalStateException(s"Failed to parse standard library:\n$message")
+    AstTransform.program(cst)
+
+  // Provides the parsed standard library program.
+  lazy val standardProgram: ProgramFile =
+    parseStandardProgram()
+
+  // Provides the export environment for the standard library.
+  lazy val standardExports: TypeChecker.ExportEnv =
+    val (exports, errors) =
+      TypeChecker.extractExports(standardProgram, TypeChecker.emptyExportEnv, includeNonExported = true)
+    if errors.nonEmpty then
+      val message = errors.map(_.message).mkString("\n")
+      throw new IllegalStateException(s"Failed to extract standard library exports:\n$message")
+    exports
+
+  // Provides the typed standard library program for runtime evaluation.
+  lazy val typedProgram: TypedAst.Program =
+    val (typed, errors) = TypeChecker.checkProgramWithoutStandard(standardProgram, TypeChecker.emptyExportEnv)
+    typed

--- a/src/main/scala/com/github/peterzeller/minifumo/builtins/standard.minifumo
+++ b/src/main/scala/com/github/peterzeller/minifumo/builtins/standard.minifumo
@@ -1,0 +1,700 @@
+export data Bool = True | False
+
+export data Nat = Zero | Suc(n Nat)
+
+export data Int = Int(positive Bool, n Nat)
+
+export data List[T] = Nil | Cons(head T, tail List[T])
+
+export data Tree[K, V] = Leaf | Node(key K, value V, left Tree[K, V], right Tree[K, V])
+
+export data Char = Char(rune Nat)
+
+export data String = String(value List[Char])
+
+export typeclass OpNeg[T]
+    // Returns the negated value.
+    fun opNeg(value T) T
+
+export typeclass OpPlus[T]
+    // Adds two values together.
+    fun opPlus(a T, b T) T
+
+export typeclass OpMinus[T]
+    // Subtracts the second value from the first.
+    fun opMinus(a T, b T) T
+
+export typeclass OpTimes[T]
+    // Multiplies two values.
+    fun opTimes(a T, b T) T
+
+export typeclass OpDiv[T]
+    // Divides the first value by the second.
+    fun opDiv(a T, b T) T
+
+export typeclass OpMod[T]
+    // Computes the remainder of the first value divided by the second.
+    fun opMod(a T, b T) T
+
+export typeclass OpLt[T]
+    // Returns True if the first value is less than the second.
+    fun opLt(a T, b T) Bool
+
+export typeclass OpLe[T]
+    // Returns True if the first value is less than or equal to the second.
+    fun opLe(a T, b T) Bool
+
+export typeclass OpAnd[T]
+    // Computes the logical and of two values.
+    fun opAnd(a T, b T) T
+
+export typeclass OpOr[T]
+    // Computes the logical or of two values.
+    fun opOr(a T, b T) T
+
+export typeclass Eq[T]
+    // Returns True when both values are equal.
+    fun eq(a T, b T) Bool
+
+export typeclass Show[T]
+    // Converts a value to a string.
+    fun show(value T) String
+
+export typeclass Sequence[S, T]
+    // Gets the element at the given index.
+    fun get(seq S, index Int) T
+    // Sets the element at the given index.
+    fun set(seq S, index Int, value T) S
+    // Checks whether the sequence contains the value.
+    fun contains(seq S, value T) Bool
+
+export typeclass Map[M, K, V]
+    // Inserts a value at the given key.
+    fun put(map M, key K, value V) M
+    // Looks up the value for the given key.
+    fun lookup(map M, key K) V
+
+export typeclass Set[S, T]
+    // Checks whether the set contains the value.
+    fun contains(set S, value T) Bool
+    // Adds a value to the set.
+    fun add(set S, value T) S
+
+// Returns True when both Bool values match.
+fun boolEq(a Bool, b Bool) Bool
+    match a
+        case True
+            match b
+                case True
+                    True
+                case False
+                    False
+        case False
+            match b
+                case True
+                    False
+                case False
+                    True
+
+// Returns the negation of the Bool value.
+fun opNot(value Bool) Bool
+    match value
+        case True
+            False
+        case False
+            True
+
+// Returns True when the Nat is Zero.
+fun natIsZero(n Nat) Bool
+    match n
+        case Zero
+            True
+        case Suc(_)
+            False
+
+// Returns True when both Nat values are equal.
+fun natEq(a Nat, b Nat) Bool
+    match a
+        case Zero
+            match b
+                case Zero
+                    True
+                case Suc(_)
+                    False
+        case Suc(aTail)
+            match b
+                case Zero
+                    False
+                case Suc(bTail)
+                    natEq(aTail, bTail)
+
+// Returns True when the first Nat is less than the second.
+fun natLt(a Nat, b Nat) Bool
+    match a
+        case Zero
+            match b
+                case Zero
+                    False
+                case Suc(_)
+                    True
+        case Suc(aTail)
+            match b
+                case Zero
+                    False
+                case Suc(bTail)
+                    natLt(aTail, bTail)
+
+// Returns True when the first Nat is less than or equal to the second.
+fun natLe(a Nat, b Nat) Bool
+    if natLt(a, b)
+        True
+    else
+        natEq(a, b)
+
+// Adds two Nat values.
+fun natAdd(a Nat, b Nat) Nat
+    match a
+        case Zero
+            b
+        case Suc(tail)
+            Suc(natAdd(tail, b))
+
+// Subtracts the second Nat from the first, returning Zero when underflowing.
+fun natSub(a Nat, b Nat) Nat
+    match a
+        case Zero
+            Zero
+        case Suc(aTail)
+            match b
+                case Zero
+                    Suc(aTail)
+                case Suc(bTail)
+                    natSub(aTail, bTail)
+
+// Multiplies two Nat values.
+fun natMul(a Nat, b Nat) Nat
+    match a
+        case Zero
+            Zero
+        case Suc(tail)
+            natAdd(b, natMul(tail, b))
+
+// Divides the first Nat by the second.
+fun natDiv(a Nat, b Nat) Nat
+    if natIsZero(b)
+        Zero
+    else
+        if natLt(a, b)
+            Zero
+        else
+            Suc(natDiv(natSub(a, b), b))
+
+// Computes the remainder of the first Nat divided by the second.
+fun natMod(a Nat, b Nat) Nat
+    if natIsZero(b)
+        a
+    else
+        if natLt(a, b)
+            a
+        else
+            natMod(natSub(a, b), b)
+
+// Normalizes an Int so zero is always positive.
+fun intNormalize(positive Bool, n Nat) Int
+    match n
+        case Zero
+            Int(True, Zero)
+        case Suc(_)
+            Int(positive, n)
+
+// Returns True when the Int represents a negative value.
+fun intIsNegative(value Int) Bool
+    match value
+        case Int(positive, n)
+            match positive
+                case True
+                    False
+                case False
+                    match n
+                        case Zero
+                            False
+                        case Suc(_)
+                            True
+
+// Extracts the Nat component from a non-negative Int.
+fun intToNat(value Int) Nat
+    match value
+        case Int(positive, n)
+            match positive
+                case True
+                    n
+                case False
+                    Zero
+
+// Converts a non-negative Int literal into a Nat value.
+fun natFromInt(value Int) Nat
+    intToNat(value)
+
+// Returns True when the two Int values are equal.
+fun intEq(a Int, b Int) Bool
+    match a
+        case Int(positiveA, nA)
+            match b
+                case Int(positiveB, nB)
+                    if natIsZero(nA)
+                        if natIsZero(nB)
+                            True
+                        else
+                            False
+                    else
+                        if boolEq(positiveA, positiveB)
+                            natEq(nA, nB)
+                        else
+                            False
+
+// Negates an Int value.
+fun intNeg(value Int) Int
+    match value
+        case Int(positive, n)
+            match n
+                case Zero
+                    Int(True, Zero)
+                case Suc(_)
+                    match positive
+                        case True
+                            Int(False, n)
+                        case False
+                            Int(True, n)
+
+// Adds two Int values.
+fun intAdd(a Int, b Int) Int
+    match a
+        case Int(positiveA, nA)
+            match b
+                case Int(positiveB, nB)
+                    if boolEq(positiveA, positiveB)
+                        intNormalize(positiveA, natAdd(nA, nB))
+                    else
+                        if natLt(nA, nB)
+                            intNormalize(positiveB, natSub(nB, nA))
+                        else
+                            intNormalize(positiveA, natSub(nA, nB))
+
+// Subtracts one Int from another.
+fun intSub(a Int, b Int) Int
+    intAdd(a, intNeg(b))
+
+// Multiplies two Int values.
+fun intMul(a Int, b Int) Int
+    match a
+        case Int(positiveA, nA)
+            match b
+                case Int(positiveB, nB)
+                    if natIsZero(nA)
+                        Int(True, Zero)
+                    else
+                        if natIsZero(nB)
+                            Int(True, Zero)
+                        else
+                            intNormalize(boolEq(positiveA, positiveB), natMul(nA, nB))
+
+// Divides one Int by another.
+fun intDiv(a Int, b Int) Int
+    match a
+        case Int(positiveA, nA)
+            match b
+                case Int(positiveB, nB)
+                    if natIsZero(nB)
+                        undefined
+                    else
+                        if natIsZero(nA)
+                            Int(True, Zero)
+                        else
+                            intNormalize(boolEq(positiveA, positiveB), natDiv(nA, nB))
+
+// Computes the remainder of dividing one Int by another.
+fun intMod(a Int, b Int) Int
+    match a
+        case Int(positiveA, nA)
+            match b
+                case Int(_, nB)
+                    if natIsZero(nB)
+                        undefined
+                    else
+                        intNormalize(positiveA, natMod(nA, nB))
+
+// Returns True when the first Int is less than the second.
+fun intLt(a Int, b Int) Bool
+    match a
+        case Int(positiveA, nA)
+            match b
+                case Int(positiveB, nB)
+                    match positiveA
+                        case True
+                            match positiveB
+                                case True
+                                    natLt(nA, nB)
+                                case False
+                                    False
+                        case False
+                            match positiveB
+                                case True
+                                    True
+                                case False
+                                    natLt(nB, nA)
+
+// Returns True when the first Int is less than or equal to the second.
+fun intLe(a Int, b Int) Bool
+    if intLt(a, b)
+        True
+    else
+        intEq(a, b)
+
+// Returns True when two Char values are equal.
+fun charEq(a Char, b Char) Bool
+    match a
+        case Char(left)
+            match b
+                case Char(right)
+                    natEq(left, right)
+
+// Returns True when the first Char is less than the second.
+fun charLt(a Char, b Char) Bool
+    match a
+        case Char(left)
+            match b
+                case Char(right)
+                    natLt(left, right)
+
+// Appends two lists together.
+fun listAppend[T](left List[T], right List[T]) List[T]
+    match left
+        case Nil
+            right
+        case Cons(head, tail)
+            Cons(head, listAppend(tail, right))
+
+// Returns the element at the given Nat index.
+fun listGetNat[T](values List[T], index Nat) T
+    match values
+        case Nil
+            undefined
+        case Cons(head, tail)
+            match index
+                case Zero
+                    head
+                case Suc(rest)
+                    listGetNat(tail, rest)
+
+// Updates the element at the given Nat index.
+fun listSetNat[T](values List[T], index Nat, value T) List[T]
+    match values
+        case Nil
+            Nil
+        case Cons(head, tail)
+            match index
+                case Zero
+                    Cons(value, tail)
+                case Suc(rest)
+                    Cons(head, listSetNat(tail, rest, value))
+
+// Checks whether a list contains the given value.
+fun listContains[T](values List[T], value T) Bool given (eq Eq[T])
+    match values
+        case Nil
+            False
+        case Cons(head, tail)
+            if value == head
+                True
+            else
+                listContains(tail, value)
+
+// Returns True when two lists are equal.
+fun listEq[T](left List[T], right List[T]) Bool given (eq Eq[T])
+    match left
+        case Nil
+            match right
+                case Nil
+                    True
+                case Cons(_, _)
+                    False
+        case Cons(leftHead, leftTail)
+            match right
+                case Nil
+                    False
+                case Cons(rightHead, rightTail)
+                    if leftHead == rightHead
+                        listEq(leftTail, rightTail)
+                    else
+                        False
+
+// Returns True when the first list of Char is less than the second.
+fun charListLt(left List[Char], right List[Char]) Bool
+    match left
+        case Nil
+            match right
+                case Nil
+                    False
+                case Cons(_, _)
+                    True
+        case Cons(leftHead, leftTail)
+            match right
+                case Nil
+                    False
+                case Cons(rightHead, rightTail)
+                    if charEq(leftHead, rightHead)
+                        charListLt(leftTail, rightTail)
+                    else
+                        charLt(leftHead, rightHead)
+
+// Returns True when the first list of Char is less than or equal to the second.
+fun charListLe(left List[Char], right List[Char]) Bool
+    if charListLt(left, right)
+        True
+    else
+        if listEq(left, right)
+            True
+        else
+            False
+
+// Appends two String values.
+fun stringAppend(a String, b String) String
+    match a
+        case String(left)
+            match b
+                case String(right)
+                    String(listAppend(left, right))
+
+// Builds a single-character String.
+fun stringFromChar(value Char) String
+    String(Cons(value, Nil))
+
+// Builds a Char from a digit Nat (0-9).
+fun digitChar(value Nat) Char
+    Char(natAdd(natFromInt(48), value))
+
+// Converts a Nat into a base-10 String.
+fun natToString(value Nat) String
+    if natLt(value, natFromInt(10))
+        stringFromChar(digitChar(value))
+    else
+        stringAppend(
+            natToString(natDiv(value, natFromInt(10))),
+            stringFromChar(digitChar(natMod(value, natFromInt(10))))
+        )
+
+// Converts an Int into a base-10 String.
+fun intToString(value Int) String
+    match value
+        case Int(positive, n)
+            if natIsZero(n)
+                "0"
+            else
+                match positive
+                    case True
+                        natToString(n)
+                    case False
+                        stringAppend("-", natToString(n))
+
+// Returns True when the first String is less than the second.
+fun stringLt(a String, b String) Bool
+    match a
+        case String(left)
+            match b
+                case String(right)
+                    charListLt(left, right)
+
+// Returns True when the first String is less than or equal to the second.
+fun stringLe(a String, b String) Bool
+    match a
+        case String(left)
+            match b
+                case String(right)
+                    charListLe(left, right)
+
+// Converts a list into a String using Cons/Nil notation.
+fun listToString[T](values List[T]) String given (s Show[T])
+    match values
+        case Nil
+            "Nil"
+        case Cons(head, tail)
+            stringAppend(
+                "Cons(",
+                stringAppend(show(head), stringAppend(", ", stringAppend(listToString(tail), ")")))
+            )
+
+// Defines a stub println that returns unit.
+fun println[T](value T) unit
+    unit
+
+instance eqBool for Eq[Bool]
+    // Compares two Bool values.
+    fun eq(a Bool, b Bool) Bool
+        boolEq(a, b)
+
+instance eqNat for Eq[Nat]
+    // Compares two Nat values.
+    fun eq(a Nat, b Nat) Bool
+        natEq(a, b)
+
+instance eqInt for Eq[Int]
+    // Compares two Int values.
+    fun eq(a Int, b Int) Bool
+        intEq(a, b)
+
+instance eqChar for Eq[Char]
+    // Compares two Char values.
+    fun eq(a Char, b Char) Bool
+        charEq(a, b)
+
+instance eqString for Eq[String]
+    // Compares two String values.
+    fun eq(a String, b String) Bool
+        match a
+            case String(left)
+                match b
+                    case String(right)
+                        listEq(left, right)
+
+
+instance opNegInt for OpNeg[Int]
+    // Negates an Int value.
+    fun opNeg(value Int) Int
+        intNeg(value)
+
+instance opPlusInt for OpPlus[Int]
+    // Adds two Int values.
+    fun opPlus(a Int, b Int) Int
+        intAdd(a, b)
+
+instance opMinusInt for OpMinus[Int]
+    // Subtracts two Int values.
+    fun opMinus(a Int, b Int) Int
+        intSub(a, b)
+
+instance opTimesInt for OpTimes[Int]
+    // Multiplies two Int values.
+    fun opTimes(a Int, b Int) Int
+        intMul(a, b)
+
+instance opDivInt for OpDiv[Int]
+    // Divides two Int values.
+    fun opDiv(a Int, b Int) Int
+        intDiv(a, b)
+
+instance opModInt for OpMod[Int]
+    // Computes the remainder of dividing two Int values.
+    fun opMod(a Int, b Int) Int
+        intMod(a, b)
+
+instance opLtInt for OpLt[Int]
+    // Compares two Int values for ordering.
+    fun opLt(a Int, b Int) Bool
+        intLt(a, b)
+
+instance opLeInt for OpLe[Int]
+    // Compares two Int values for ordering.
+    fun opLe(a Int, b Int) Bool
+        intLe(a, b)
+
+instance opAndBool for OpAnd[Bool]
+    // Computes the logical and of two Bool values.
+    fun opAnd(a Bool, b Bool) Bool
+        match a
+            case True
+                b
+            case False
+                False
+
+instance opOrBool for OpOr[Bool]
+    // Computes the logical or of two Bool values.
+    fun opOr(a Bool, b Bool) Bool
+        match a
+            case True
+                True
+            case False
+                b
+
+instance opPlusString for OpPlus[String]
+    // Concatenates two String values.
+    fun opPlus(a String, b String) String
+        stringAppend(a, b)
+
+instance opLtString for OpLt[String]
+    // Compares two String values for ordering.
+    fun opLt(a String, b String) Bool
+        stringLt(a, b)
+
+instance opLeString for OpLe[String]
+    // Compares two String values for ordering.
+    fun opLe(a String, b String) Bool
+        stringLe(a, b)
+
+instance opPlusList[T] for OpPlus[List[T]]
+    // Concatenates two lists.
+    fun opPlus(a List[T], b List[T]) List[T]
+        listAppend(a, b)
+
+instance listSequence[T] for Sequence[List[T], T] given (eq Eq[T])
+    // Gets a list element by index.
+    fun get(seq List[T], index Int) T
+        if intIsNegative(index)
+            undefined
+        else
+            listGetNat(seq, intToNat(index))
+    // Sets a list element by index.
+    fun set(seq List[T], index Int, value T) List[T]
+        if intIsNegative(index)
+            seq
+        else
+            listSetNat(seq, intToNat(index), value)
+    // Checks whether a list contains the value.
+    fun contains(seq List[T], value T) Bool
+        listContains(seq, value)
+
+instance listSet[T] for Set[List[T], T] given (eq Eq[T])
+    // Checks whether a list-based set contains the value.
+    fun contains(set List[T], value T) Bool
+        listContains(set, value)
+    // Adds a value to a list-based set.
+    fun add(set List[T], value T) List[T]
+        if listContains(set, value)
+            set
+        else
+            Cons(value, set)
+
+// Inserts a key/value pair into the tree.
+fun treePut[K, V](tree Tree[K, V], key K, value V) Tree[K, V] given (lt OpLt[K], eq Eq[K])
+    match tree
+        case Leaf
+            Node(key, value, Leaf, Leaf)
+        case Node(k, v, left, right)
+            if key == k
+                Node(k, value, left, right)
+            else
+                if key < k
+                    Node(k, v, treePut(left, key, value), right)
+                else
+                    Node(k, v, left, treePut(right, key, value))
+
+// Looks up a key in the tree.
+fun treeLookup[K, V](tree Tree[K, V], key K) V given (lt OpLt[K], eq Eq[K])
+    match tree
+        case Leaf
+            undefined
+        case Node(k, v, left, right)
+            if key == k
+                v
+            else
+                if key < k
+                    treeLookup(left, key)
+                else
+                    treeLookup(right, key)
+
+instance treeMap[K, V] for Map[Tree[K, V], K, V] given (lt OpLt[K], eq Eq[K])
+    // Inserts a key/value pair into a tree map.
+    fun put(tree Tree[K, V], key K, value V) Tree[K, V]
+        treePut(tree, key, value)
+    // Looks up a value in a tree map.
+    fun lookup(tree Tree[K, V], key K) V
+        treeLookup(tree, key)

--- a/src/main/scala/com/github/peterzeller/minifumo/interpreter/Interpreter.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/interpreter/Interpreter.scala
@@ -91,22 +91,25 @@ object Interpreter:
           throw new IllegalArgumentException(s"Constructor ${ctor.name} expects ${ctor.arity} args, got ${args.length}")
         (Value.AdtVal(ctor.name, args), env)
       case fun: FunctionSymbol =>
-        env.functions.get(fun) match
-          case Some(funDef) =>
-            if args.length != funDef.params.length then
-              throw new IllegalArgumentException(
-                s"Function ${fun.name} expects ${funDef.params.length} args, got ${args.length}"
-              )
-            val bindings: Map[TermSymbol, Value] = funDef.params.zip(args).toMap
-            val envWithParams = env.pushScope(bindings)
-            try
-              val (result, envAfter) = evalSuite(funDef.body, envWithParams)
-              (result, envAfter.popScope)
-            catch
-              case ReturnSignal(value, envAfter) =>
-                (value, envAfter.popScope)
-          case None =>
-            throw new IllegalArgumentException(s"Unknown function: ${fun.name}")
+        if fun.name == "println" then
+          builtinPrintln(args, env)
+        else
+          env.functions.get(fun) match
+            case Some(funDef) =>
+              if args.length != funDef.params.length then
+                throw new IllegalArgumentException(
+                  s"Function ${fun.name} expects ${funDef.params.length} args, got ${args.length}"
+                )
+              val bindings: Map[TermSymbol, Value] = funDef.params.zip(args).toMap
+              val envWithParams = env.pushScope(bindings)
+              try
+                val (result, envAfter) = evalSuite(funDef.body, envWithParams)
+                (result, envAfter.popScope)
+              catch
+                case ReturnSignal(value, envAfter) =>
+                  (value, envAfter.popScope)
+            case None =>
+              throw new IllegalArgumentException(s"Unknown function: ${fun.name}")
       case err: ErrorSymbol =>
         throw new IllegalArgumentException(s"Unknown symbol: ${err.name}")
       case term: TermSymbol =>
@@ -160,7 +163,7 @@ object Interpreter:
               case Expr.Var(fieldSymbol, _) => fieldSymbol.name
               case Expr.Lit(Literal.StringLit(value), _) => value
               case other => throw new IllegalArgumentException(s"Expected field name, got: $other")
-            builtinDot(List(target, Value.StringVal(fieldName)), envAfterTarget)
+            builtinDot(List(target, stringToValue(fieldName)), envAfterTarget)
           case _ =>
             val (calleeValue, envAfterCallee) = evalExpr(callee, env)
             val (argValues, envAfterArgs) = evalArgs(args, envAfterCallee)
@@ -210,10 +213,10 @@ object Interpreter:
         (Value.UnitVal, envAfterValue.updateBinding(symbol, value))
       case Expr.IfThenElse(cond, thenExpr, elseExpr, _) =>
         val (condValue, envAfterCond) = evalExpr(cond, env)
-        condValue match
-          case Value.BoolVal(true) => evalExpr(thenExpr, envAfterCond)
-          case Value.BoolVal(false) => evalExpr(elseExpr, envAfterCond)
-          case other => throw new IllegalArgumentException(s"Expected Bool in if condition, got: $other")
+        valueToBool(condValue) match
+          case Some(true) => evalExpr(thenExpr, envAfterCond)
+          case Some(false) => evalExpr(elseExpr, envAfterCond)
+          case None => throw new IllegalArgumentException(s"Expected Bool in if condition, got: $condValue")
       case Expr.For(symbol, inExpr, body, _) =>
         val (collection, envAfterCollection) = evalExpr(inExpr, env)
         val elements = iterableElements(collection)
@@ -230,14 +233,14 @@ object Interpreter:
         @tailrec
         def loop(loopEnv: Env, lastValue: Value): (Value, Env) =
           val (condValue, envAfterCond) = evalExpr(cond, loopEnv)
-          condValue match
-            case Value.BoolVal(true) =>
+          valueToBool(condValue) match
+            case Some(true) =>
               val (value, envAfterBody) = evalSuite(body, envAfterCond)
               loop(envAfterBody, value)
-            case Value.BoolVal(false) =>
+            case Some(false) =>
               (lastValue, envAfterCond)
-            case other =>
-              throw new IllegalArgumentException(s"Expected Bool in while condition, got: $other")
+            case None =>
+              throw new IllegalArgumentException(s"Expected Bool in while condition, got: $condValue")
 
         loop(env, Value.UnitVal)
       case Expr.Match(scrutinee, cases, _) =>
@@ -301,26 +304,125 @@ object Interpreter:
         }
     Env(List(Map.empty), functions, ctors, instances)
 
+  // Wraps a boolean value as a Bool constructor value.
+  private def boolToValue(value: Boolean): Value =
+    if value then Value.AdtVal("True", Nil) else Value.AdtVal("False", Nil)
+
+  // Extracts a boolean value from Bool constructors or runtime booleans.
+  private def valueToBool(value: Value): Option[Boolean] =
+    value match
+      case Value.BoolVal(v) => Some(v)
+      case Value.AdtVal("True", Nil) => Some(true)
+      case Value.AdtVal("False", Nil) => Some(false)
+      case _ => None
+
+  // Wraps a natural number as a Nat constructor value.
+  private def natToValue(value: BigInt): Value =
+    if value <= 0 then Value.AdtVal("Zero", Nil)
+    else Value.AdtVal("Suc", List(natToValue(value - 1)))
+
+  // Extracts a natural number from Nat constructor values.
+  private def valueToNat(value: Value): Option[BigInt] =
+    value match
+      case Value.AdtVal("Zero", Nil) => Some(0)
+      case Value.AdtVal("Suc", List(rest)) => valueToNat(rest).map(_ + 1)
+      case _ => None
+
+  // Wraps an integer as an Int constructor value.
+  private def intToValue(value: BigInt): Value =
+    val positive = value >= 0
+    val magnitude = value.abs
+    Value.AdtVal("Int", List(boolToValue(positive), natToValue(magnitude)))
+
+  // Extracts an integer from Int constructor values or runtime integers.
+  private def valueToInt(value: Value): Option[BigInt] =
+    value match
+      case Value.IntVal(v) => Some(v)
+      case Value.AdtVal("Int", List(signValue, natValue)) =>
+        for
+          sign <- valueToBool(signValue)
+          magnitude <- valueToNat(natValue)
+        yield if sign then magnitude else -magnitude
+      case _ => None
+
+  // Wraps a list of values as a List constructor chain.
+  private def listToValue(values: Vector[Value]): Value =
+    values.foldRight(Value.AdtVal("Nil", Nil)) { (value, acc) =>
+      Value.AdtVal("Cons", List(value, acc))
+    }
+
+  // Extracts a list of values from List constructors or runtime lists.
+  private def valueToList(value: Value): Option[Vector[Value]] =
+    value match
+      case Value.ListVal(values) => Some(values)
+      case Value.AdtVal("Nil", Nil) => Some(Vector.empty)
+      case Value.AdtVal("Cons", List(head, tail)) =>
+        valueToList(tail).map(rest => head +: rest)
+      case _ => None
+
+  // Wraps a code point as a Char constructor value.
+  private def charToValue(codePoint: Int): Value =
+    Value.AdtVal("Char", List(natToValue(BigInt(codePoint))))
+
+  // Extracts a code point from Char constructor values.
+  private def valueToChar(value: Value): Option[Int] =
+    value match
+      case Value.AdtVal("Char", List(runeValue)) =>
+        valueToNat(runeValue).map(_.toInt)
+      case _ => None
+
+  // Wraps a JVM string as a String constructor value.
+  private def stringToValue(value: String): Value =
+    val chars = value.toVector.map(ch => charToValue(ch.toInt))
+    Value.AdtVal("String", List(listToValue(chars)))
+
+  // Extracts a JVM string from String constructors or runtime strings.
+  private def valueToString(value: Value): Option[String] =
+    value match
+      case Value.StringVal(v) => Some(v)
+      case Value.AdtVal("String", List(charsValue)) =>
+        valueToList(charsValue).flatMap { chars =>
+          val decoded = chars.map(valueToChar)
+          if decoded.forall(_.isDefined) then
+            Some(decoded.flatten.map(_.toChar).mkString)
+          else
+            None
+        }
+      case _ => None
+
+  // Compares two values, normalizing standard library constructors.
+  private def valueEquals(left: Value, right: Value): Boolean =
+    (valueToInt(left), valueToInt(right)) match
+      case (Some(a), Some(b)) => a == b
+      case _ =>
+        (valueToBool(left), valueToBool(right)) match
+          case (Some(a), Some(b)) => a == b
+          case _ =>
+            (valueToString(left), valueToString(right)) match
+              case (Some(a), Some(b)) => a == b
+              case _ =>
+                (valueToList(left), valueToList(right)) match
+                  case (Some(a), Some(b)) => a == b
+                  case _ => left == right
+
   private val baseValues: Map[String, Value] =
     Map(
       "unit" -> Value.UnitVal,
-      "undefined" -> Value.UndefinedVal,
-      "true" -> Value.BoolVal(true),
-      "false" -> Value.BoolVal(false)
+      "undefined" -> Value.UndefinedVal
     )
 
   private def literalValue(literal: Literal): Value =
     literal match
-      case Literal.IntLit(value) => Value.IntVal(BigInt(value))
-      case Literal.BoolLit(value) => Value.BoolVal(value)
-      case Literal.StringLit(value) => Value.StringVal(value)
+      case Literal.IntLit(value) => intToValue(BigInt(value))
+      case Literal.BoolLit(value) => boolToValue(value)
+      case Literal.StringLit(value) => stringToValue(value)
 
   private def matchPattern(pattern: Pattern, value: Value, env: Env): Option[Map[TermSymbol, Value]] =
     val res = pattern match
       case Pattern.Wildcard() =>
         Some(Map.empty)
       case Pattern.Lit(literal) =>
-        if literalValue(literal) == value then Some(Map.empty) else None
+        if valueEquals(literalValue(literal), value) then Some(Map.empty) else None
       case Pattern.Binder(symbol) =>
         Some(Map(symbol -> value))
       case Pattern.Ctor(symbol, args) =>
@@ -342,102 +444,159 @@ object Interpreter:
       None
 
   private def iterableElements(value: Value): List[Value] =
-    value match
-      case Value.ListVal(values) => values.toList
-      case Value.SetVal(values) => values.toList
-      case Value.MapVal(values) => values.keys.toList
-      case Value.AdtVal("Nil", Nil) => Nil
-      case Value.AdtVal("Cons", List(head, tail)) => head :: iterableElements(tail)
-      case other =>
-        throw new IllegalArgumentException(s"Expected iterable, got: $other")
+    valueToList(value)
+      .map(_.toList)
+      .orElse {
+        value match
+          case Value.SetVal(values) => Some(values.toList)
+          case Value.MapVal(values) => Some(values.keys.toList)
+          case _ => None
+      }
+      .getOrElse(throw new IllegalArgumentException(s"Expected iterable, got: $value"))
 
   private def builtins: Map[String, Builtin] =
     Map(
       "println" -> builtinPrintln,
-      "+" -> builtinPlus,
-      "-" -> builtinMinus,
-      "*" -> builtinMul,
-      "/" -> builtinDiv,
-      "%" -> builtinMod,
-      "<" -> builtinCompare(_ < 0),
-      "<=" -> builtinCompare(_ <= 0),
-      ">" -> builtinCompare(_ > 0),
-      ">=" -> builtinCompare(_ >= 0),
-      "==" -> builtinEq(_ == _),
-      "!=" -> builtinEq(_ != _),
-      "and" -> builtinBool(_ && _),
-      "or" -> builtinBool(_ || _),
-      "list" -> builtinList,
-      "set" -> builtinSet,
-      "map" -> builtinMap,
-      "len" -> builtinLen,
-      "get" -> builtinGet,
-      "put" -> builtinPut,
-      "add" -> builtinAdd,
-      "remove" -> builtinRemove,
-      "contains" -> builtinContains,
-      "keys" -> builtinKeys,
-      "values" -> builtinValues,
-      "append" -> builtinAppend,
-      "concat" -> builtinConcat,
-      "slice" -> builtinSlice
+      "nativePrintln" -> builtinPrintln,
+      "nativeIntPlus" -> builtinPlus,
+      "nativeIntMinus" -> builtinMinus,
+      "nativeIntTimes" -> builtinMul,
+      "nativeIntDiv" -> builtinDiv,
+      "nativeIntMod" -> builtinMod,
+      "nativeIntNeg" -> builtinNeg,
+      "nativeIntLt" -> builtinCompare(_ < 0),
+      "nativeIntLe" -> builtinCompare(_ <= 0),
+      "nativeBoolAnd" -> builtinBool(_ && _),
+      "nativeBoolOr" -> builtinBool(_ || _),
+      "nativeBoolNot" -> builtinNot,
+      "nativeStringPlus" -> builtinStringPlus,
+      "nativeStringLt" -> builtinStringCompare(_ < 0),
+      "nativeStringLe" -> builtinStringCompare(_ <= 0),
+      "nativeEq" -> builtinEq,
+      "nativeShow" -> builtinShow,
+      "nativeListConcat" -> builtinConcat,
+      "nativeListGet" -> builtinGet,
+      "nativeListSet" -> builtinSetIndex,
+      "nativeListContains" -> builtinContains,
+      "nativeSetContains" -> builtinContains,
+      "nativeSetAdd" -> builtinAdd,
+      "nativeMapPut" -> builtinPut,
+      "nativeMapGet" -> builtinGet,
+      "." -> builtinDot
     )
 
   private def builtinPrintln(args: List[Value], env: Env): (Value, Env) =
     // TODO do not use global state, pass in the PrintStream via the Env
-    args.foreach(value => System.out.println(renderValue(value)))
-    (Value.UnitVal, env)
+    args match
+      case List(value) =>
+        val text = valueToString(value).getOrElse(renderValue(value))
+        System.out.println(text)
+        (Value.UnitVal, env)
+      case other =>
+        throw new IllegalArgumentException(s"nativePrintln expects 1 arg, got: $other")
 
   private def builtinPlus(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.IntVal(a), Value.IntVal(b)) => (Value.IntVal(a + b), env)
-      case List(Value.StringVal(a), Value.StringVal(b)) => (Value.StringVal(a + b), env)
-      case List(Value.ListVal(a), Value.ListVal(b)) => (Value.ListVal(a ++ b), env)
-      case other => throw new IllegalArgumentException(s"Unsupported + args: $other")
+      case List(a, b) =>
+        (valueToInt(a), valueToInt(b)) match
+          case (Some(left), Some(right)) => (intToValue(left + right), env)
+          case _ => throw new IllegalArgumentException(s"Unsupported nativeIntPlus args: $args")
+      case other => throw new IllegalArgumentException(s"Unsupported nativeIntPlus args: $other")
 
   private def builtinMinus(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.IntVal(a)) => (Value.IntVal(-a), env)
-      case List(Value.IntVal(a), Value.IntVal(b)) => (Value.IntVal(a - b), env)
-      case other => throw new IllegalArgumentException(s"Unsupported - args: $other")
+      case List(a, b) =>
+        (valueToInt(a), valueToInt(b)) match
+          case (Some(left), Some(right)) => (intToValue(left - right), env)
+          case _ => throw new IllegalArgumentException(s"Unsupported nativeIntMinus args: $args")
+      case other => throw new IllegalArgumentException(s"Unsupported nativeIntMinus args: $other")
 
   private def builtinMul(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.IntVal(a), Value.IntVal(b)) => (Value.IntVal(a * b), env)
-      case other => throw new IllegalArgumentException(s"Unsupported * args: $other")
+      case List(a, b) =>
+        (valueToInt(a), valueToInt(b)) match
+          case (Some(left), Some(right)) => (intToValue(left * right), env)
+          case _ => throw new IllegalArgumentException(s"Unsupported nativeIntTimes args: $args")
+      case other => throw new IllegalArgumentException(s"Unsupported nativeIntTimes args: $other")
 
   private def builtinDiv(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.IntVal(a), Value.IntVal(b)) => (Value.IntVal(a / b), env)
-      case other => throw new IllegalArgumentException(s"Unsupported / args: $other")
+      case List(a, b) =>
+        (valueToInt(a), valueToInt(b)) match
+          case (Some(left), Some(right)) => (intToValue(left / right), env)
+          case _ => throw new IllegalArgumentException(s"Unsupported nativeIntDiv args: $args")
+      case other => throw new IllegalArgumentException(s"Unsupported nativeIntDiv args: $other")
 
   private def builtinMod(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.IntVal(a), Value.IntVal(b)) => (Value.IntVal(a % b), env)
-      case other => throw new IllegalArgumentException(s"Unsupported % args: $other")
+      case List(a, b) =>
+        (valueToInt(a), valueToInt(b)) match
+          case (Some(left), Some(right)) => (intToValue(left % right), env)
+          case _ => throw new IllegalArgumentException(s"Unsupported nativeIntMod args: $args")
+      case other => throw new IllegalArgumentException(s"Unsupported nativeIntMod args: $other")
+
+  // Negates an integer value.
+  private def builtinNeg(args: List[Value], env: Env): (Value, Env) =
+    args match
+      case List(a) =>
+        valueToInt(a) match
+          case Some(value) => (intToValue(-value), env)
+          case None => throw new IllegalArgumentException(s"Unsupported nativeIntNeg args: $args")
+      case other => throw new IllegalArgumentException(s"Unsupported nativeIntNeg args: $other")
 
   private def builtinCompare(pred: Int => Boolean): Builtin =
     (args, env) =>
       args match
-        case List(Value.IntVal(a), Value.IntVal(b)) => (Value.BoolVal(pred(a.compare(b))), env)
-        case List(Value.StringVal(a), Value.StringVal(b)) =>
-          (Value.BoolVal(pred(a.compareTo(b))), env)
-        case other => throw new IllegalArgumentException(s"Unsupported comparison args: $other")
+        case List(a, b) =>
+          (valueToInt(a), valueToInt(b)) match
+            case (Some(left), Some(right)) => (boolToValue(pred(left.compare(right))), env)
+            case _ => throw new IllegalArgumentException(s"Unsupported nativeInt comparison args: $args")
+        case other => throw new IllegalArgumentException(s"Unsupported nativeInt comparison args: $other")
 
-  private def builtinEq(pred: (Value, Value) => Boolean): Builtin =
+  // Concatenates two strings.
+  private def builtinStringPlus(args: List[Value], env: Env): (Value, Env) =
+    args match
+      case List(a, b) =>
+        (valueToString(a), valueToString(b)) match
+          case (Some(left), Some(right)) => (stringToValue(left + right), env)
+          case _ => throw new IllegalArgumentException(s"Unsupported nativeStringPlus args: $args")
+      case other => throw new IllegalArgumentException(s"Unsupported nativeStringPlus args: $other")
+
+  // Compares two strings using the supplied predicate.
+  private def builtinStringCompare(pred: Int => Boolean): Builtin =
     (args, env) =>
       args match
-        case List(a, b) => (Value.BoolVal(pred(a, b)), env)
-        case other => throw new IllegalArgumentException(s"Unsupported equality args: $other")
+        case List(a, b) =>
+          (valueToString(a), valueToString(b)) match
+            case (Some(left), Some(right)) => (boolToValue(pred(left.compareTo(right))), env)
+            case _ => throw new IllegalArgumentException(s"Unsupported nativeString comparison args: $args")
+        case other => throw new IllegalArgumentException(s"Unsupported nativeString comparison args: $other")
+
+  private def builtinEq(args: List[Value], env: Env): (Value, Env) =
+    args match
+      case List(a, b) => (boolToValue(valueEquals(a, b)), env)
+      case other => throw new IllegalArgumentException(s"Unsupported equality args: $other")
 
   private def builtinBool(op: (Boolean, Boolean) => Boolean): Builtin =
     (args, env) =>
       args match
-        case List(Value.BoolVal(a), Value.BoolVal(b)) => (Value.BoolVal(op(a, b)), env)
+        case List(a, b) =>
+          (valueToBool(a), valueToBool(b)) match
+            case (Some(left), Some(right)) => (boolToValue(op(left, right)), env)
+            case _ => throw new IllegalArgumentException(s"Unsupported boolean args: $args")
         case other => throw new IllegalArgumentException(s"Unsupported boolean args: $other")
 
+  // Negates a boolean value.
+  private def builtinNot(args: List[Value], env: Env): (Value, Env) =
+    args match
+      case List(a) =>
+        valueToBool(a) match
+          case Some(value) => (boolToValue(!value), env)
+          case None => throw new IllegalArgumentException(s"Unsupported nativeBoolNot args: $args")
+      case other => throw new IllegalArgumentException(s"Unsupported nativeBoolNot args: $other")
+
   private def builtinList(args: List[Value], env: Env): (Value, Env) =
-    (Value.ListVal(args.toVector), env)
+    (listToValue(args.toVector), env)
 
   private def builtinSet(args: List[Value], env: Env): (Value, Env) =
     (Value.SetVal(args.toSet), env)
@@ -455,23 +614,38 @@ object Interpreter:
 
   private def builtinLen(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.ListVal(values)) => (Value.IntVal(values.length), env)
-      case List(Value.SetVal(values)) => (Value.IntVal(values.size), env)
-      case List(Value.MapVal(values)) => (Value.IntVal(values.size), env)
-      case List(Value.StringVal(value)) => (Value.IntVal(value.length), env)
-      case other => throw new IllegalArgumentException(s"Unsupported len args: $other")
+      case List(value) =>
+        valueToList(value) match
+          case Some(values) => (intToValue(values.length), env)
+          case None =>
+            valueToString(value) match
+              case Some(text) => (intToValue(text.length), env)
+              case None =>
+                value match
+                  case Value.SetVal(values) => (intToValue(values.size), env)
+                  case Value.MapVal(values) => (intToValue(values.size), env)
+                  case other => throw new IllegalArgumentException(s"Unsupported len args: $other")
 
   private def builtinGet(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.ListVal(values), Value.IntVal(index)) =>
-        val i = index.toInt
-        if i < 0 || i >= values.length then
-          throw new IllegalArgumentException(s"List index out of bounds: $i")
-        (values(i), env)
-      case List(Value.MapVal(values), key) =>
-        values.get(key) match
-          case Some(value) => (value, env)
-          case None => throw new IllegalArgumentException(s"Missing key: ${renderValue(key)}")
+      case List(collection, indexValue) =>
+        valueToList(collection) match
+          case Some(values) =>
+            valueToInt(indexValue) match
+              case Some(index) =>
+                val i = index.toInt
+                if i < 0 || i >= values.length then
+                  throw new IllegalArgumentException(s"List index out of bounds: $i")
+                (values(i), env)
+              case None =>
+                throw new IllegalArgumentException(s"List index is not an Int: $indexValue")
+          case None =>
+            collection match
+              case Value.MapVal(values) =>
+                values.get(indexValue) match
+                  case Some(value) => (value, env)
+                  case None => throw new IllegalArgumentException(s"Missing key: ${renderValue(indexValue)}")
+              case other => throw new IllegalArgumentException(s"Unsupported get args: $other")
       case other => throw new IllegalArgumentException(s"Unsupported get args: $other")
 
   private def builtinPut(args: List[Value], env: Env): (Value, Env) =
@@ -495,61 +669,101 @@ object Interpreter:
   private def builtinContains(args: List[Value], env: Env): (Value, Env) =
     args match
       case List(Value.SetVal(values), value) =>
-        (Value.BoolVal(values.contains(value)), env)
-      case List(Value.ListVal(values), value) =>
-        (Value.BoolVal(values.contains(value)), env)
-      case List(Value.MapVal(values), key) =>
-        (Value.BoolVal(values.contains(key)), env)
+        (boolToValue(values.exists(valueEquals(_, value))), env)
+      case List(collection, value) =>
+        valueToList(collection) match
+          case Some(values) => (boolToValue(values.exists(valueEquals(_, value))), env)
+          case None =>
+            collection match
+              case Value.MapVal(values) => (boolToValue(values.contains(value)), env)
+              case other => throw new IllegalArgumentException(s"Unsupported contains args: $other")
       case other => throw new IllegalArgumentException(s"Unsupported contains args: $other")
 
   private def builtinKeys(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.MapVal(values)) => (Value.ListVal(values.keys.toVector), env)
+      case List(Value.MapVal(values)) => (listToValue(values.keys.toVector), env)
       case other => throw new IllegalArgumentException(s"Unsupported keys args: $other")
 
   private def builtinValues(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.MapVal(values)) => (Value.ListVal(values.values.toVector), env)
+      case List(Value.MapVal(values)) => (listToValue(values.values.toVector), env)
       case other => throw new IllegalArgumentException(s"Unsupported values args: $other")
 
   private def builtinAppend(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.ListVal(values), value) => (Value.ListVal(values :+ value), env)
+      case List(collection, value) =>
+        valueToList(collection) match
+          case Some(values) => (listToValue(values :+ value), env)
+          case None => throw new IllegalArgumentException(s"Unsupported append args: $args")
       case other => throw new IllegalArgumentException(s"Unsupported append args: $other")
 
   private def builtinConcat(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.ListVal(a), Value.ListVal(b)) => (Value.ListVal(a ++ b), env)
+      case List(a, b) =>
+        (valueToList(a), valueToList(b)) match
+          case (Some(left), Some(right)) => (listToValue(left ++ right), env)
+          case _ => throw new IllegalArgumentException(s"Unsupported concat args: $args")
       case other => throw new IllegalArgumentException(s"Unsupported concat args: $other")
 
   private def builtinSlice(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.ListVal(values), Value.IntVal(start), Value.IntVal(end)) =>
-        val s = start.toInt
-        val e = end.toInt
-        (Value.ListVal(values.slice(s, e)), env)
+      case List(collection, startValue, endValue) =>
+        (valueToList(collection), valueToInt(startValue), valueToInt(endValue)) match
+          case (Some(values), Some(start), Some(end)) =>
+            val s = start.toInt
+            val e = end.toInt
+            (listToValue(values.slice(s, e)), env)
+          case _ => throw new IllegalArgumentException(s"Unsupported slice args: $args")
       case other => throw new IllegalArgumentException(s"Unsupported slice args: $other")
+
+  // Updates a list element at the given index.
+  private def builtinSetIndex(args: List[Value], env: Env): (Value, Env) =
+    args match
+      case List(collection, indexValue, value) =>
+        (valueToList(collection), valueToInt(indexValue)) match
+          case (Some(values), Some(index)) =>
+            val i = index.toInt
+            if i < 0 || i >= values.length then
+              throw new IllegalArgumentException(s"List index out of bounds: $i")
+            val updated = values.updated(i, value)
+            (listToValue(updated), env)
+          case _ => throw new IllegalArgumentException(s"Unsupported nativeListSet args: $args")
+      case other => throw new IllegalArgumentException(s"Unsupported nativeListSet args: $other")
+
+  // Renders a value into a String constructor value.
+  private def builtinShow(args: List[Value], env: Env): (Value, Env) =
+    args match
+      case List(value) => (stringToValue(renderValue(value)), env)
+      case other => throw new IllegalArgumentException(s"Unsupported nativeShow args: $other")
 
   private def builtinDot(args: List[Value], env: Env): (Value, Env) =
     args match
-      case List(Value.MapVal(values), Value.StringVal(field)) =>
-        values.get(Value.StringVal(field)) match
+      case List(Value.MapVal(values), fieldValue) =>
+        val key = valueToString(fieldValue).map(Value.StringVal.apply).getOrElse(fieldValue)
+        values.get(key) match
           case Some(value) => (value, env)
-          case None => throw new IllegalArgumentException(s"Missing map field: $field")
+          case None => throw new IllegalArgumentException(s"Missing map field: ${renderValue(fieldValue)}")
       case other => throw new IllegalArgumentException(s"Unsupported . args: $other")
 
   private def renderValue(value: Value): String =
-    value match
-      case Value.IntVal(v) => v.toString
-      case Value.BoolVal(v) => v.toString
-      case Value.StringVal(v) => v
-      case Value.ListVal(values) => values.map(renderValue).mkString("[", ", ", "]")
-      case Value.SetVal(values) => values.map(renderValue).mkString("Set(", ", ", ")")
-      case Value.MapVal(values) =>
-        values.map { case (k, v) => s"${renderValue(k)}: ${renderValue(v)}" }.mkString("Map(", ", ", ")")
-      case Value.InstanceVal(_) => "<instance>"
-      case Value.AdtVal(name, args) =>
-        if args.isEmpty then name else s"$name${args.map(renderValue).mkString("(", ", ", ")")}"
-      case Value.UnitVal => "unit"
-      case Value.UndefinedVal => "undefined"
-      case Value.FuncVal(_) => "<function>"
+    valueToInt(value)
+      .map(_.toString)
+      .orElse(valueToBool(value).map(_.toString))
+      .orElse(valueToString(value))
+      .orElse(valueToChar(value).map(code => s"'${code.toChar}'"))
+      .getOrElse {
+        value match
+          case Value.SetVal(values) => values.map(renderValue).mkString("Set(", ", ", ")")
+          case Value.MapVal(values) =>
+            values.map { case (k, v) => s"${renderValue(k)}: ${renderValue(v)}" }.mkString("Map(", ", ", ")")
+          case Value.InstanceVal(_) => "<instance>"
+          case Value.AdtVal(name, args) =>
+            if args.isEmpty then name else s"$name${args.map(renderValue).mkString("(", ", ", ")")}"
+          case Value.UnitVal => "unit"
+          case Value.UndefinedVal => "undefined"
+          case Value.FuncVal(_) => "<function>"
+          case Value.IntVal(v) => v.toString
+          case Value.BoolVal(v) => v.toString
+          case Value.StringVal(v) => v
+          case Value.ListVal(values) => values.map(renderValue).mkString("[", ", ", "]")
+      }

--- a/src/main/scala/com/github/peterzeller/minifumo/typing/TypeChecker.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/typing/TypeChecker.scala
@@ -1,6 +1,7 @@
 package com.github.peterzeller.minifumo.typing
 
 import com.github.peterzeller.minifumo.ast
+import com.github.peterzeller.minifumo.builtins.Standard
 import com.github.peterzeller.minifumo.typing.TypedAst.*
 
 import scala.collection.mutable.ListBuffer
@@ -69,45 +70,103 @@ object TypeChecker:
       id
 
   private val builtinTypeNames: Set[String] =
-    Set("Int", "Bool", "String", "List", "Set", "Map", "unit")
+    Set("Set", "Map", "unit")
 
   private val baseTypes: Map[String, Type] =
     Map(
-      "Int" -> Type.Name("Int"),
-      "Bool" -> Type.Name("Bool"),
-      "String" -> Type.Name("String"),
       "unit" -> Type.Name("unit")
     )
 
   private val baseValues: Map[String, BuiltinValueSymbol] =
     Map(
       "unit" -> BuiltinValueSymbol("unit", baseTypes("unit")),
-      "undefined" -> BuiltinValueSymbol("undefined", Type.Unknown),
-      "true" -> BuiltinValueSymbol("true", baseTypes("Bool")),
-      "false" -> BuiltinValueSymbol("false", baseTypes("Bool"))
+      "undefined" -> BuiltinValueSymbol("undefined", Type.Unknown)
     )
 
   private val baseFunctions: Map[String, BuiltinFunctionSymbol] =
     Map(
       "println" -> BuiltinFunctionSymbol("println", Type.Fun(List(Type.Unknown), baseTypes("unit"))),
-      "+" -> BuiltinFunctionSymbol("+", Type.Fun(List(baseTypes("Int"), baseTypes("Int")), baseTypes("Int"))),
-      "-" -> BuiltinFunctionSymbol("-", Type.Fun(List(baseTypes("Int"), baseTypes("Int")), baseTypes("Int"))),
-      "*" -> BuiltinFunctionSymbol("*", Type.Fun(List(baseTypes("Int"), baseTypes("Int")), baseTypes("Int"))),
-      "/" -> BuiltinFunctionSymbol("/", Type.Fun(List(baseTypes("Int"), baseTypes("Int")), baseTypes("Int"))),
-      "%" -> BuiltinFunctionSymbol("%", Type.Fun(List(baseTypes("Int"), baseTypes("Int")), baseTypes("Int"))),
-      "<" -> BuiltinFunctionSymbol("<", Type.Fun(List(baseTypes("Int"), baseTypes("Int")), baseTypes("Bool"))),
-      "<=" -> BuiltinFunctionSymbol("<=", Type.Fun(List(baseTypes("Int"), baseTypes("Int")), baseTypes("Bool"))),
-      ">" -> BuiltinFunctionSymbol(">", Type.Fun(List(baseTypes("Int"), baseTypes("Int")), baseTypes("Bool"))),
-      ">=" -> BuiltinFunctionSymbol(">=", Type.Fun(List(baseTypes("Int"), baseTypes("Int")), baseTypes("Bool"))),
-      "==" -> BuiltinFunctionSymbol("==", Type.Fun(List(Type.Unknown, Type.Unknown), baseTypes("Bool"))),
-      "!=" -> BuiltinFunctionSymbol("!=", Type.Fun(List(Type.Unknown, Type.Unknown), baseTypes("Bool"))),
-      "and" -> BuiltinFunctionSymbol("and", Type.Fun(List(baseTypes("Bool"), baseTypes("Bool")), baseTypes("Bool"))),
-      "or" -> BuiltinFunctionSymbol("or", Type.Fun(List(baseTypes("Bool"), baseTypes("Bool")), baseTypes("Bool"))),
+      "nativePrintln" -> BuiltinFunctionSymbol("nativePrintln", Type.Fun(List(Type.Name("String")), baseTypes("unit"))),
+      "nativeIntPlus" -> BuiltinFunctionSymbol("nativeIntPlus", Type.Fun(List(Type.Name("Int"), Type.Name("Int")), Type.Name("Int"))),
+      "nativeIntMinus" -> BuiltinFunctionSymbol("nativeIntMinus", Type.Fun(List(Type.Name("Int"), Type.Name("Int")), Type.Name("Int"))),
+      "nativeIntTimes" -> BuiltinFunctionSymbol("nativeIntTimes", Type.Fun(List(Type.Name("Int"), Type.Name("Int")), Type.Name("Int"))),
+      "nativeIntDiv" -> BuiltinFunctionSymbol("nativeIntDiv", Type.Fun(List(Type.Name("Int"), Type.Name("Int")), Type.Name("Int"))),
+      "nativeIntMod" -> BuiltinFunctionSymbol("nativeIntMod", Type.Fun(List(Type.Name("Int"), Type.Name("Int")), Type.Name("Int"))),
+      "nativeIntNeg" -> BuiltinFunctionSymbol("nativeIntNeg", Type.Fun(List(Type.Name("Int")), Type.Name("Int"))),
+      "nativeIntLt" -> BuiltinFunctionSymbol("nativeIntLt", Type.Fun(List(Type.Name("Int"), Type.Name("Int")), Type.Name("Bool"))),
+      "nativeIntLe" -> BuiltinFunctionSymbol("nativeIntLe", Type.Fun(List(Type.Name("Int"), Type.Name("Int")), Type.Name("Bool"))),
+      "nativeStringPlus" -> BuiltinFunctionSymbol("nativeStringPlus", Type.Fun(List(Type.Name("String"), Type.Name("String")), Type.Name("String"))),
+      "nativeStringLt" -> BuiltinFunctionSymbol("nativeStringLt", Type.Fun(List(Type.Name("String"), Type.Name("String")), Type.Name("Bool"))),
+      "nativeStringLe" -> BuiltinFunctionSymbol("nativeStringLe", Type.Fun(List(Type.Name("String"), Type.Name("String")), Type.Name("Bool"))),
+      "nativeBoolAnd" -> BuiltinFunctionSymbol("nativeBoolAnd", Type.Fun(List(Type.Name("Bool"), Type.Name("Bool")), Type.Name("Bool"))),
+      "nativeBoolOr" -> BuiltinFunctionSymbol("nativeBoolOr", Type.Fun(List(Type.Name("Bool"), Type.Name("Bool")), Type.Name("Bool"))),
+      "nativeBoolNot" -> BuiltinFunctionSymbol("nativeBoolNot", Type.Fun(List(Type.Name("Bool")), Type.Name("Bool"))),
+      "nativeEq" -> BuiltinFunctionSymbol("nativeEq", Type.Fun(List(Type.Unknown, Type.Unknown), Type.Name("Bool"))),
+      "nativeShow" -> BuiltinFunctionSymbol("nativeShow", Type.Fun(List(Type.Unknown), Type.Name("String"))),
+      "nativeListConcat" -> BuiltinFunctionSymbol("nativeListConcat", Type.Fun(List(Type.Unknown, Type.Unknown), Type.Unknown)),
+      "nativeListGet" -> BuiltinFunctionSymbol("nativeListGet", Type.Fun(List(Type.Unknown, Type.Name("Int")), Type.Unknown)),
+      "nativeListSet" -> BuiltinFunctionSymbol("nativeListSet", Type.Fun(List(Type.Unknown, Type.Name("Int"), Type.Unknown), Type.Unknown)),
+      "nativeListContains" -> BuiltinFunctionSymbol("nativeListContains", Type.Fun(List(Type.Unknown, Type.Unknown), Type.Name("Bool"))),
+      "nativeSetContains" -> BuiltinFunctionSymbol("nativeSetContains", Type.Fun(List(Type.Unknown, Type.Unknown), Type.Name("Bool"))),
+      "nativeSetAdd" -> BuiltinFunctionSymbol("nativeSetAdd", Type.Fun(List(Type.Unknown, Type.Unknown), Type.Unknown)),
+      "nativeMapPut" -> BuiltinFunctionSymbol("nativeMapPut", Type.Fun(List(Type.Unknown, Type.Unknown, Type.Unknown), Type.Unknown)),
+      "nativeMapGet" -> BuiltinFunctionSymbol("nativeMapGet", Type.Fun(List(Type.Unknown, Type.Unknown), Type.Unknown)),
       "." -> BuiltinFunctionSymbol(".", Type.Fun(List(Type.Unknown, Type.Unknown), Type.Unknown))
     )
 
-  def checkProgram(program: ast.ProgramFile, importedExports: ExportEnv = emptyExportEnv): (Program, List[TypeError]) =
-    val (exports, exportErrors) = extractExports(program, importedExports, includeNonExported = true)
+  // Merges two export environments, preferring entries from the override environment.
+  def mergeExports(base: ExportEnv, overrideEnv: ExportEnv): ExportEnv =
+    val merged = ExportEnv(
+      functions = base.functions ++ overrideEnv.functions,
+      ctors = base.ctors ++ overrideEnv.ctors,
+      types = base.types ++ overrideEnv.types,
+      typeClasses = base.typeClasses ++ overrideEnv.typeClasses,
+      instances = base.instances ++ overrideEnv.instances,
+      memberIndex = Map.empty
+    )
+    val memberIndex = merged.typeClasses.values
+      .flatMap(tc => tc.members.map(_.name).distinct.map(_ -> tc))
+      .groupBy(_._1)
+      .view
+      .mapValues(_.map(_._2).toList)
+      .toMap
+    merged.copy(memberIndex = memberIndex)
+
+  // Adds the standard library exports to an import environment.
+  def withStandardExports(importedExports: ExportEnv): ExportEnv =
+    mergeExports(Standard.standardExports, importedExports)
+
+  // Type checks a program, including standard library exports by default.
+  def checkProgram(program: ast.ProgramFile, importedExports: ExportEnv = Standard.standardExports): (Program, List[TypeError]) =
+    checkProgramInternal(program, importedExports, includeStandard = true)
+
+  // Type checks a program without automatically adding the standard library.
+  def checkProgramWithoutStandard(
+      program: ast.ProgramFile,
+      importedExports: ExportEnv = emptyExportEnv
+    ): (Program, List[TypeError]) =
+    checkProgramInternal(program, importedExports, includeStandard = false)
+
+  // Shared implementation for type checking with optional standard library.
+  private def checkProgramInternal(
+      program: ast.ProgramFile,
+      importedExports: ExportEnv,
+      includeStandard: Boolean
+    ): (Program, List[TypeError]) =
+    val combinedExports =
+      if includeStandard then withStandardExports(importedExports) else importedExports
+    val shadowedTypes = if includeStandard then Standard.standardExports.types.keySet else Set.empty
+    val shadowedCtors = if includeStandard then Standard.standardExports.ctors.keySet else Set.empty
+    val shadowedTypeClasses = if includeStandard then Standard.standardExports.typeClasses.keySet else Set.empty
+    val (exports, exportErrors) =
+      extractExports(
+        program,
+        combinedExports,
+        includeNonExported = true,
+        shadowedTypes = shadowedTypes,
+        shadowedCtors = shadowedCtors,
+        shadowedTypeClasses = shadowedTypeClasses
+      )
     val errors = ListBuffer.empty[TypeError]
     errors ++= exportErrors
     val typedItems = program.items.map {
@@ -145,7 +204,10 @@ object TypeChecker:
   def extractExports(
       program: ast.ProgramFile,
       baseExports: ExportEnv = emptyExportEnv,
-      includeNonExported: Boolean = true
+      includeNonExported: Boolean = true,
+      shadowedTypes: Set[String] = Set.empty,
+      shadowedCtors: Set[String] = Set.empty,
+      shadowedTypeClasses: Set[String] = Set.empty
     ): (ExportEnv, List[TypeError]) =
     val errors = ListBuffer.empty[TypeError]
     var functions = baseExports.functions
@@ -154,11 +216,17 @@ object TypeChecker:
     var typeClasses = baseExports.typeClasses
     var instances = baseExports.instances
     var memberIndex = baseExports.memberIndex
+    val localTypes = scala.collection.mutable.Set.empty[String]
+    val localCtors = scala.collection.mutable.Set.empty[String]
+    val localTypeClasses = scala.collection.mutable.Set.empty[String]
 
     for item <- program.items do {
       item match
       case ast.TopLevel.DataDecl(name, typeParams, ctorDecls, exported) if includeNonExported || exported =>
-        if types.contains(name) then
+        val isShadowedType = shadowedTypes.contains(name)
+        if localTypes.contains(name) then
+          errors += errorAt(item.source, s"Duplicate data type: $name")
+        else if types.contains(name) && !isShadowedType then
           errors += errorAt(item.source, s"Duplicate data type: $name")
         val typeParamsTypes = typeParams.map(Type.Name.apply)
         val resultType =
@@ -176,12 +244,15 @@ object TypeChecker:
           }
         }
         ctorSymbols.zip(ctorDecls).foreach { case (ctorSymbol, ctorDecl) =>
-          if ctors.contains(ctorSymbol.name) then
+          if localCtors.contains(ctorSymbol.name) then
             errors += errorAt(ctorDecl.source, s"Duplicate constructor: ${ctorSymbol.name}")
-          else
-            ctors = ctors + (ctorSymbol.name -> ctorSymbol)
+          else if ctors.contains(ctorSymbol.name) && !shadowedCtors.contains(ctorSymbol.name) then
+            errors += errorAt(ctorDecl.source, s"Duplicate constructor: ${ctorSymbol.name}")
+          ctors = ctors + (ctorSymbol.name -> ctorSymbol)
+          localCtors += ctorSymbol.name
         }
         types = types + (name -> DataType(name, typeParams, ctorSymbols))
+        localTypes += name
         ctorDecls.foreach { ctor =>
           ctor.fields.foreach { field =>
             errors ++= validateAstType(field.tpe, typeParams.toSet, ExportEnv(functions, ctors, types, typeClasses, instances, memberIndex))
@@ -209,7 +280,10 @@ object TypeChecker:
           errors ++= validateAstType(tpe, typeParamSet, ExportEnv(functions, ctors, types, typeClasses, instances, memberIndex))
         }
       case ast.TopLevel.TypeClassDecl(name, typeParams, members, exported) if includeNonExported || exported =>
-        if typeClasses.contains(name) then
+        val isShadowedTypeClass = shadowedTypeClasses.contains(name)
+        if localTypeClasses.contains(name) then
+          errors += errorAt(item.source, s"Duplicate typeclass: $name")
+        else if typeClasses.contains(name) && !isShadowedTypeClass then
           errors += errorAt(item.source, s"Duplicate typeclass: $name")
         val memberSigs = members.map { member =>
           if member.givenParams.nonEmpty then
@@ -224,6 +298,7 @@ object TypeChecker:
           )
         }
         typeClasses = typeClasses + (name -> TypeClassDef(name, typeParams, memberSigs))
+        localTypeClasses += name
         memberSigs.foreach { member =>
           val typeParamSet = (typeParams ++ member.typeParams).toSet
           member.params.foreach { param =>
@@ -465,7 +540,7 @@ object TypeChecker:
       idSupply: IdSupply
     ): (Expr, List[TypeError]) =
     expr match
-      case ast.Expr.Lit(value) => synthLit(value, expr.source)
+      case ast.Expr.Lit(value) => synthLit(value, expr.source, env)
       case ast.Expr.Var(name) => synthVar(name, expr.source, env)
       case ast.Expr.Paren(inner) => synthParen(inner, expr.source, env, idSupply)
       case ast.Expr.Block(exprs) => synthBlock(exprs, expr.source, env, idSupply)
@@ -500,7 +575,7 @@ object TypeChecker:
       idSupply: IdSupply
     ): (Expr, List[TypeError]) =
     expr match
-      case ast.Expr.Lit(value) => checkLit(value, expectedType, expr.source)
+      case ast.Expr.Lit(value) => checkLit(value, expectedType, expr.source, env)
       case ast.Expr.Var(name) => checkVar(name, expectedType, expr.source, env)
       case ast.Expr.Paren(inner) => checkParen(inner, expectedType, expr.source, env, expectedReturn, idSupply)
       case ast.Expr.Block(exprs) =>
@@ -536,15 +611,22 @@ object TypeChecker:
         checkReturn(valueExpr, expectedType, expr.source, env, expectedReturn, idSupply)
 
   // T-Lit: Γ ⊢ n ⇒ Int / Γ ⊢ true ⇒ Bool / Γ ⊢ "s" ⇒ String
-  private def synthLit(value: ast.Literal, source: ast.SourceRange): (Expr, List[TypeError]) =
-    val tpe = literalType(value)
-    (Expr.Lit(value, tpe)(source), Nil)
+  private def synthLit(value: ast.Literal, source: ast.SourceRange, env: TypeEnv): (Expr, List[TypeError]) =
+    val errors = ListBuffer.empty[TypeError]
+    val tpe = literalType(value, source, env, errors)
+    (Expr.Lit(value, tpe)(source), errors.toList)
 
   // T-Lit-Check: Γ ⊢ e ⇐ T  if  Γ ⊢ e ⇒ S  and  S ≈ T
-  private def checkLit(value: ast.Literal, expectedType: Type, source: ast.SourceRange): (Expr, List[TypeError]) =
-    val tpe = literalType(value)
-    val (checkedType, errors) = ensureExpectedType(tpe, Some(expectedType), source)
-    (Expr.Lit(value, checkedType)(source), errors)
+  private def checkLit(
+      value: ast.Literal,
+      expectedType: Type,
+      source: ast.SourceRange,
+      env: TypeEnv
+    ): (Expr, List[TypeError]) =
+    val errors = ListBuffer.empty[TypeError]
+    val tpe = literalType(value, source, env, errors)
+    val (checkedType, expectedErrors) = ensureExpectedType(tpe, Some(expectedType), source)
+    (Expr.Lit(value, checkedType)(source), errors.toList ++ expectedErrors)
 
   // T-Var: Γ(x) = T  ⇒  Γ ⊢ x ⇒ T
   private def synthVar(name: String, source: ast.SourceRange, env: TypeEnv): (Expr, List[TypeError]) =
@@ -700,10 +782,6 @@ object TypeChecker:
             val (typedArgs, argsErrors) = typeExprs(args, env, expectedReturn, None, idSupply)
             val errors = calleeErrors ++ argsErrors :+ errorAt(callee.source, "Field access typing is not implemented")
             (Expr.CallFun(typedCallee, typedArgs, Nil, Type.Unknown)(source), errors)
-          case Expr.Var(symbol, _) if symbol.name == "-" && args.length == 1 =>
-            val (typedArg, argErrors) = checkExpr(args.head, env, expectedReturn, baseTypes("Int"), idSupply)
-            val errors = calleeErrors ++ argErrors
-            (Expr.CallFun(typedCallee, List(typedArg), Nil, baseTypes("Int"))(source), errors)
           case Expr.Var(symbol: CtorSymbol, _) =>
             val (typedExpr, ctorErrors) = typeCtorCall(symbol, args, expectedType, source, env, expectedReturn, idSupply)
             (typedExpr, calleeErrors ++ ctorErrors)
@@ -969,7 +1047,13 @@ object TypeChecker:
       val instanceCandidates = env.exports.instances.values.toList.filter { inst =>
         filter.forall(f => isCompatible(inst.head, f)) && matchInstanceHead(inst, goal)
       }
-      val resolved = instanceCandidates.flatMap { inst =>
+      val filteredCandidates =
+        if instanceCandidates.nonEmpty then
+          val minTypeParams = instanceCandidates.map(_.typeParams.length).min
+          instanceCandidates.filter(_.typeParams.length == minTypeParams)
+        else
+          instanceCandidates
+      val resolved = filteredCandidates.flatMap { inst =>
         val (bindingsOpt, matchErrors) = matchInstance(inst, goal, source)
         bindingsOpt.flatMap { case (bindings, instantiatedHead) =>
           val prunedBindings = dropSelfBindings(bindings)
@@ -1222,13 +1306,15 @@ object TypeChecker:
       env: TypeEnv,
       idSupply: IdSupply
     ): (Expr, List[TypeError]) =
-    val (typedCond, condErrors) = checkExpr(cond, env, env.expectedReturn, baseTypes("Bool"), idSupply)
+    val errors = ListBuffer.empty[TypeError]
+    val boolType = resolveTypeName("Bool", source, env, errors)
+    val (typedCond, condErrors) = checkExpr(cond, env, env.expectedReturn, boolType, idSupply)
     val (typedThen, thenErrors) = synthesizeExpr(thenExpr, env, idSupply)
     val (typedElse, elseErrors) = synthesizeExpr(elseExpr, env, idSupply)
     val (resultType, branchErrors) = unifyBranchTypes("if", typedThen.tpe, typedElse.tpe, source)
     (
       Expr.IfThenElse(typedCond, typedThen, typedElse, resultType)(source),
-      condErrors ++ thenErrors ++ elseErrors ++ branchErrors
+      errors.toList ++ condErrors ++ thenErrors ++ elseErrors ++ branchErrors
     )
 
   // T-If-Check: Γ ⊢ c ⇐ Bool  and  Γ ⊢ t ⇐ T  and  Γ ⊢ e ⇐ T  ⇒  Γ ⊢ if c then t else e ⇐ T
@@ -1242,13 +1328,15 @@ object TypeChecker:
       expectedReturn: Type,
       idSupply: IdSupply
     ): (Expr, List[TypeError]) =
-    val (typedCond, condErrors) = checkExpr(cond, env, expectedReturn, baseTypes("Bool"), idSupply)
+    val errors = ListBuffer.empty[TypeError]
+    val boolType = resolveTypeName("Bool", source, env, errors)
+    val (typedCond, condErrors) = checkExpr(cond, env, expectedReturn, boolType, idSupply)
     val (typedThen, thenErrors) = checkExpr(thenExpr, env, expectedReturn, expectedType, idSupply)
     val (typedElse, elseErrors) = checkExpr(elseExpr, env, expectedReturn, expectedType, idSupply)
     val (resultType, branchErrors) = unifyBranchTypes("if", typedThen.tpe, typedElse.tpe, source)
     (
       Expr.IfThenElse(typedCond, typedThen, typedElse, expectedType)(source),
-      condErrors ++ thenErrors ++ elseErrors ++ branchErrors
+      errors.toList ++ condErrors ++ thenErrors ++ elseErrors ++ branchErrors
     )
 
   // T-For: Γ ⊢ xs ⇒ Iterable[T]  and  Γ,x:T ⊢ e ⇒ U  ⇒  Γ ⊢ for x in xs do e ⇒ U
@@ -1298,12 +1386,14 @@ object TypeChecker:
       env: TypeEnv,
       idSupply: IdSupply
     ): (Expr, List[TypeError]) =
-    val (typedCond, condErrors) = checkExpr(cond, env, env.expectedReturn, baseTypes("Bool"), idSupply)
+    val errors = ListBuffer.empty[TypeError]
+    val boolType = resolveTypeName("Bool", source, env, errors)
+    val (typedCond, condErrors) = checkExpr(cond, env, env.expectedReturn, boolType, idSupply)
     val (typedBody, bodyErrors) = typeSuite(body, env, env.expectedReturn, None, idSupply)
     val (checkedType, expectedErrors) = ensureExpectedType(baseTypes("unit"), Some(baseTypes("unit")), source)
     (
       Expr.While(typedCond, typedBody, checkedType)(source),
-      condErrors ++ bodyErrors ++ expectedErrors
+      errors.toList ++ condErrors ++ bodyErrors ++ expectedErrors
     )
 
   // T-While-Check: Γ ⊢ c ⇐ Bool  and  Γ ⊢ e ⇐ unit  ⇒  Γ ⊢ while c do e ⇐ unit
@@ -1316,12 +1406,14 @@ object TypeChecker:
       expectedReturn: Type,
       idSupply: IdSupply
     ): (Expr, List[TypeError]) =
-    val (typedCond, condErrors) = checkExpr(cond, env, expectedReturn, baseTypes("Bool"), idSupply)
+    val errors = ListBuffer.empty[TypeError]
+    val boolType = resolveTypeName("Bool", source, env, errors)
+    val (typedCond, condErrors) = checkExpr(cond, env, expectedReturn, boolType, idSupply)
     val (typedBody, bodyErrors) = typeSuite(body, env, expectedReturn, Some(baseTypes("unit")), idSupply)
     val (checkedType, expectedErrors) = ensureExpectedType(baseTypes("unit"), Some(expectedType), source)
     (
       Expr.While(typedCond, typedBody, checkedType)(source),
-      condErrors ++ bodyErrors ++ expectedErrors
+      errors.toList ++ condErrors ++ bodyErrors ++ expectedErrors
     )
 
   // T-Match: Γ ⊢ e ⇒ T and Γ ⊢ cases ⇒ U  ⇒  Γ ⊢ match e with cases ⇒ U
@@ -1433,16 +1525,14 @@ object TypeChecker:
       case ast.Pattern.Wildcard() =>
         (Pattern.Wildcard()(pattern.source), Map.empty, Nil)
       case ast.Pattern.Lit(value) =>
-        val litType = literalType(value)
-        val errors =
-          if isCompatible(expectedType, litType) then Nil
-          else List(
-            errorAt(
-              source,
-              s"Pattern literal has type ${renderType(litType)}, expected ${renderType(expectedType)}"
-            )
+        val errors = ListBuffer.empty[TypeError]
+        val litType = literalType(value, source, env, errors)
+        if !isCompatible(expectedType, litType) then
+          errors += errorAt(
+            source,
+            s"Pattern literal has type ${renderType(litType)}, expected ${renderType(expectedType)}"
           )
-        (Pattern.Lit(value)(source), Map.empty, errors)
+        (Pattern.Lit(value)(source), Map.empty, errors.toList)
       case ast.Pattern.BinderOrCtor0(name) =>
         env.exports.ctors.get(name) match
           case Some(ctor) if ctor.arity == 0 =>
@@ -1644,7 +1734,18 @@ object TypeChecker:
     (expected, actual) match
       case (Type.Unknown, _) => true
       case (_, Type.Unknown) => true
-      case _ => expected == actual
+      case (Type.Name(left), Type.Name(right)) => left == right
+      case (Type.App(leftBase, leftArgs), Type.App(rightBase, rightArgs)) =>
+        isCompatible(leftBase, rightBase) &&
+          leftArgs
+            .zipAll(rightArgs, Type.Unknown, Type.Unknown)
+            .forall { case (left, right) => isCompatible(left, right) }
+      case (Type.Fun(leftParams, leftResult), Type.Fun(rightParams, rightResult)) =>
+        leftParams
+          .zipAll(rightParams, Type.Unknown, Type.Unknown)
+          .forall { case (left, right) => isCompatible(left, right) } &&
+          isCompatible(leftResult, rightResult)
+      case _ => false
 
   private def resolveSymbol(name: String, env: TypeEnv): Option[Symbol] =
     env.resolveLocal(name)
@@ -1653,6 +1754,23 @@ object TypeChecker:
       .orElse(env.exports.functions.get(name))
       .orElse(env.exports.ctors.get(name))
       .orElse(baseFunctions.get(name))
+
+  // Resolves a type name from the standard library or builtins.
+  private def resolveTypeName(
+      name: String,
+      source: ast.SourceRange,
+      env: TypeEnv,
+      errors: ListBuffer[TypeError]
+    ): Type =
+    baseTypes.get(name)
+      .orElse(env.exports.types.get(name).map(_ => Type.Name(name)))
+      .orElse {
+        if builtinTypeNames.contains(name) then Some(Type.Name(name)) else None
+      }
+      .getOrElse {
+        errors += errorAt(source, s"Unknown type name: $name")
+        Type.Unknown
+      }
 
   private def fromAstType(tpe: ast.Type): Type =
     tpe match
@@ -1686,11 +1804,17 @@ object TypeChecker:
         params.flatMap(param => validateTypedType(param, typeParams, exports, source)) ++ validateTypedType(result, typeParams, exports, source)
       case Type.Unknown => Nil
 
-  private def literalType(literal: ast.Literal): Type =
+  // Resolves literal types based on the standard library.
+  private def literalType(
+      literal: ast.Literal,
+      source: ast.SourceRange,
+      env: TypeEnv,
+      errors: ListBuffer[TypeError]
+    ): Type =
     literal match
-      case ast.Literal.IntLit(_) => baseTypes("Int")
-      case ast.Literal.BoolLit(_) => baseTypes("Bool")
-      case ast.Literal.StringLit(_) => baseTypes("String")
+      case ast.Literal.IntLit(_) => resolveTypeName("Int", source, env, errors)
+      case ast.Literal.BoolLit(_) => resolveTypeName("Bool", source, env, errors)
+      case ast.Literal.StringLit(_) => resolveTypeName("String", source, env, errors)
 
   private def renderType(tpe: Type): String =
     tpe match

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -2,10 +2,23 @@
 import com.github.peterzeller.minifumo.parser.parseInput
 import com.github.peterzeller.minifumo.antlr.MinifumoParser
 import com.github.peterzeller.minifumo.ast.AstTransform
+import com.github.peterzeller.minifumo.builtins.Standard
 import com.github.peterzeller.minifumo.interpreter.Interpreter
 import com.github.peterzeller.minifumo.typing.TypeChecker
+import com.github.peterzeller.minifumo.typing.TypedAst
 // https://scalameta.org/munit/docs/getting-started.html
 class MySuite extends munit.FunSuite {
+  // Builds a Nat value for testing.
+  private def natValue(value: Int): Interpreter.Value =
+    if value <= 0 then
+      Interpreter.Value.AdtVal("Zero", Nil)
+    else
+      Interpreter.Value.AdtVal("Suc", List(natValue(value - 1)))
+
+  // Builds an Int value for testing.
+  private def intValue(value: Int): Interpreter.Value =
+    val sign = if value >= 0 then Interpreter.Value.AdtVal("True", Nil) else Interpreter.Value.AdtVal("False", Nil)
+    Interpreter.Value.AdtVal("Int", List(sign, natValue(math.abs(value))))
 
   test("interpreter evals main with 1+2") {
     val (c, _) = parseInput("""
@@ -15,8 +28,9 @@ class MySuite extends munit.FunSuite {
     val ast = AstTransform.program(c)
     val (typed, errors) = TypeChecker.checkProgram(ast)
     assertEquals(errors, List())
-    val result = Interpreter.evalProg(typed, "main")
-    assertEquals(result, Interpreter.Value.IntVal(BigInt(3)))
+    val combined = TypedAst.Program(Standard.typedProgram.items ++ typed.items)(typed.source)
+    val result = Interpreter.evalProg(combined, "main")
+    assertEquals(result, intValue(3))
   }
 
   test("type checker can type ints") {
@@ -29,8 +43,9 @@ class MySuite extends munit.FunSuite {
     val ast = AstTransform.program(c)
     val (typed, errors) = TypeChecker.checkProgram(ast)
     assert(errors == List())
-    val result = Interpreter.evalProg(typed, "main")
-    assertEquals(result, Interpreter.Value.IntVal(BigInt(3)))
+    val combined = TypedAst.Program(Standard.typedProgram.items ++ typed.items)(typed.source)
+    val result = Interpreter.evalProg(combined, "main")
+    assertEquals(result, intValue(3))
   }
 
   test("type checker can instantiate generic functions") {
@@ -44,8 +59,9 @@ class MySuite extends munit.FunSuite {
     val ast = AstTransform.program(c)
     val (typed, errors) = TypeChecker.checkProgram(ast)
     assert(errors == List())
-    val result = Interpreter.evalProg(typed, "main")
-    assertEquals(result, Interpreter.Value.IntVal(BigInt(42)))
+    val combined = TypedAst.Program(Standard.typedProgram.items ++ typed.items)(typed.source)
+    val result = Interpreter.evalProg(combined, "main")
+    assertEquals(result, intValue(42))
   }
 
 
@@ -71,7 +87,8 @@ class MySuite extends munit.FunSuite {
     val (typed, errors) = TypeChecker.checkProgram(ast)
     assert(errors.isEmpty, s"Type errors:\n${errors.mkString("\n")}")
     println("Evaluating program...")
-    val result = Interpreter.evalProg(typed, "main")
+    val combined = TypedAst.Program(Standard.typedProgram.items ++ typed.items)(typed.source)
+    val result = Interpreter.evalProg(combined, "main")
     assertEquals(result, Interpreter.Value.UnitVal)
   }
 }


### PR DESCRIPTION
### Motivation
- Remove reliance on interpreter-native helpers in the standard library by providing pure Minifumo implementations for core operations so stdlib behavior is expressible and testable in-language.
- Ensure examples and tests still print output by mapping the stdlib `println` stub to the interpreter's builtin printer at runtime.
- Fix earlier inline-review issues about unsafe `native*` bindings and ambiguous/shadowed instances.

### Description
- Rewrote `src/main/scala/com/github/peterzeller/minifumo/builtins/standard.minifumo` to remove all `native*` calls and provide Minifumo implementations for Bool/Nat/Int/List/Char/String helpers, comparisons, arithmetic, list ops, tree map operations, `Show`/`Eq`/`Sequence`/`Map`/`Set` instances, and string rendering utilities.
- Updated the interpreter (`Interpreter.scala`) to convert between runtime values and the ADT-style stdlib constructors (Bool/Nat/Int/List/Char/String), to route the stdlib `println` function symbol to the interpreter builtin, and to implement builtin handlers that operate on normalized ADT/wrapper values (int/string/list conversions, comparisons, contains/get/put/set operations, rendering).
- Adjusted the AST lowering in `AstTransform.scala` to map surface operators to typeclass member names (e.g. `+` -> `opPlus`, `-` -> `opMinus`, `<`/`<=`/`>`/`>=` mapping, `==`/`!=` lowering to `eq`/`opNot(eq)` and boolean operators to `opAnd`/`opOr`).
- Changed the type checker (`TypeChecker.scala`) to include standard exports by default, add helpers to merge/shadow stdlib exports, resolve literal types from the stdlib, and handle builtins that back the newly implemented runtime primitives (e.g. `nativeIntPlus`, `nativePrintln`, etc.).
- Added `Standard.scala` loader which parses and types the stdlib and exposes `standardExports` and `typedProgram` for runtime combination, and updated `Main.scala` and tests to include the typed stdlib items when evaluating programs.
- Addressed inline review comments: removed any blanket `eqAny`/`showAny` instances that were too permissive, replaced native implementations with pure stdlib code, and made `println` a unit-returning stub in the stdlib while handling printing in the interpreter.

### Testing
- Ran the full test suite with `./sbt/bin/sbt test`; all tests passed: `Passed: Total 53, Failed 0, Errors 0, Passed 53`.
- The example harness (`doc/examples`) and unit tests (`src/test/scala/*`) were exercised by the suite and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775e206f8883248a0999f5e314bd64)