### PR TITLE
Refactor type checker to use meta-vars + unification and functional env

### DIFF
--- a/doc/examples/type_error_return.minifumo
+++ b/doc/examples/type_error_return.minifumo
@@ -1,2 +1,2 @@
 fun returnString(x String) Int
-    x // error: Type mismatch in expected type: Int vs String
+    x // error: Expression has type String, expected Int

--- a/doc/examples/typeclasses_ambiguous.minifumo
+++ b/doc/examples/typeclasses_ambiguous.minifumo
@@ -4,4 +4,4 @@ typeclass Show[T]
     fun show(value T) String
 
 fun ambiguous[T](value T) String given (s1 Show[T], s2 Show[T])
-    show(value) // error: No typeclass member found: show
+    show(value) // error: Ambiguous given for Show[T]

--- a/doc/examples/typeclasses_errors.minifumo
+++ b/doc/examples/typeclasses_errors.minifumo
@@ -24,4 +24,4 @@ instance badShow for Show[String] // error: Missing member show in instance badS
 
 instance badReturn for Show[Bool]
     fun show(value Bool) Int // error: Member show returns Int, expected String
-        0 // error: Type mismatch in expected type: String vs Int
+        0 // error: Expression has type Int, expected String

--- a/src/main/scala/com/github/peterzeller/minifumo/typing/TypeChecker.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/typing/TypeChecker.scala
@@ -857,6 +857,16 @@ object TypeChecker:
     val candidates = env.exports.memberIndex.getOrElse(name, Nil).flatMap { tc =>
       tc.members.find(_.name == name).map(member => (tc, member))
     }
+    // Renders a typeclass goal with type parameter names for unresolved meta arguments.
+    def renderTypeClassGoal(tc: TypeClassDef, args: List[Type]): String =
+      if args.isEmpty then tc.name
+      else
+        val renderedArgs = args.zipAll(tc.typeParams, Type.Unknown, "").map {
+          case (Type.Meta(_), paramName) if paramName.nonEmpty => paramName
+          case (arg, _) => renderType(arg)
+        }
+        s"${tc.name}[${renderedArgs.mkString(", ")}]"
+    val failedCandidateErrors = ListBuffer.empty[List[TypeError]]
     val typedCandidates = candidates.flatMap { case (tc, member) =>
       val (envAfterTypeParams, typeParamBindings, typeArgErrors) =
         instantiateTypeParams(tc.typeParams ++ member.typeParams, Nil, env, source)
@@ -898,21 +908,26 @@ object TypeChecker:
           val matchingGivens = env.givens.filter(g => isCompatible(g.tpe, goal))
           matchingGivens match
             case param :: Nil => (List(Expr.Var(param, param.tpe)(source)), Nil, currentEnv)
-            case _ :: _ => (Nil, List(errorAt(source, s"Ambiguous given for ${renderType(goal)}")), currentEnv)
+            case _ :: _ => (Nil, List(errorAt(source, s"Ambiguous given for ${renderTypeClassGoal(tc, typeClassArgs)}")), currentEnv)
             case Nil => resolveGivenArguments(List(goal), usingArgs, currentEnv, source, idSupply, Nil)
         else
           resolveGivenArguments(List(goal), usingArgs, currentEnv, source, idSupply, Nil)
       candidateErrors ++= instanceErrors
-      instanceArgs.headOption.map { instanceExpr =>
-        val finalResultType = applySubstitutions(unifiedResult, envAfterInstance)
-        (Expr.CallTypeClassMember(instanceExpr, name, typedArgs, finalResultType)(source), candidateErrors.toList, envAfterInstance)
-      }
+      instanceArgs.headOption match
+        case Some(instanceExpr) =>
+          val finalResultType = applySubstitutions(unifiedResult, envAfterInstance)
+          Some((Expr.CallTypeClassMember(instanceExpr, name, typedArgs, finalResultType)(source), candidateErrors.toList, envAfterInstance))
+        case None =>
+          failedCandidateErrors += candidateErrors.toList
+          None
     }
     typedCandidates.distinct match
       case Nil =>
         val missingSymbol = ErrorSymbol(name, Type.Unknown)
         val baseErrors =
-          if candidates.isEmpty || errors.isEmpty then
+          if failedCandidateErrors.nonEmpty then
+            failedCandidateErrors.flatten.toList
+          else if candidates.isEmpty || errors.isEmpty then
             errors.toList :+ errorAt(source, s"No typeclass member found: $name")
           else
             errors.toList
@@ -1699,7 +1714,19 @@ object TypeChecker:
       case Some(expected) =>
         val (updatedEnv, unifiedType, errors) =
           unifyTypes(expected, actualType, env, source, "expected type")
-        (updatedEnv, unifiedType, errors)
+        val normalizedActual = applySubstitutions(actualType, updatedEnv)
+        val normalizedExpected = applySubstitutions(expected, updatedEnv)
+        val refinedErrors =
+          if errors.nonEmpty && !isCompatible(normalizedExpected, normalizedActual) then
+            List(
+              errorAt(
+                source,
+                s"Expression has type ${renderType(normalizedActual)}, expected ${renderType(normalizedExpected)}"
+              )
+            )
+          else
+            errors
+        (updatedEnv, unifiedType, refinedErrors)
       case None => (env, actualType, Nil)
 
   // Applies the current type substitutions to a type.


### PR DESCRIPTION
### Motivation

- Move the type checker from in-place mutable bindings to a more functional design where typing functions return an updated typing environment so unification state (meta substitutions) can be threaded safely.
- Add proper unification and meta type support so the checker can infer types for polymorphic functions and unify fresh meta variables during calls and checks.
- Use principled instantiation of type schemes for generic functions and typeclass members so explicit type arguments are not required in the standard library.

### Description

- Introduce `Type.Meta(id)` in `TypedAst.Type`, add `substitutions` and `nextMetaId` to `TypeEnv`, and provide `freshMeta()` to allocate meta type variables.
- Implement `applySubstitutions`, `occursInMeta`, `substituteMeta` and a unifier `unifyTypes(left,right,env,source,context)` that updates the `TypeEnv` substitutions and returns a unified type and errors.
- Thread `TypeEnv` through all expression- and suite-typing functions so every typing function returns `(typed, errors, updatedEnv)` (pure functional style) and replace many mutable binding points accordingly.
- Add `instantiateTypeParams` to create either explicit type argument bindings or fresh meta variables for polymorphic `FunctionSymbol`/`CtorSymbol`/typeclass members and updated call/typeclass/ctor checking to: instantiate scheme, unify the function's result with the expected call result, then check parameters left-to-right using the evolving env, and resolve given arguments with the current substitutions.
- Provide helpers `unifyTypesSimple` and compatibility rules that treat metas as compatible during checks, and ensure `instantiateType`/`collectTypeParamBindings` work with meta variables.
- Fix the standard library TODO by removing the explicit type argument: change `listEq[Char](left, right)` to `listEq(left, right)` in `standard.minifumo` now that inference with metas handles it.

### Testing

- I attempted to run the project test suite with `sbt test` but the environment lacks `sbt` (`bash: command not found: sbt`), so the automated test suite could not be executed.
- Performed local repository checks (file updates, grep/sed inspections) verifying that function signatures and usages were consistently updated and the TODO in `standard.minifumo` was removed; no automated compile/test run was possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978af7695ec8324a4474f7d36d51570)