### PR TITLE
Add core dependently-typed kernel with de Bruijn ops, WHNF, conversion and tests

### DIFF
--- a/src/main/scala/com/github/peterzeller/minifumo/typing/kernel/Kernel.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/typing/kernel/Kernel.scala
@@ -38,10 +38,7 @@ object Kernel {
     def lookup(index: Int): Option[Term] = types.lift(index)
 
     /** Extends the context with a new bound variable type. */
-    def extend(typ: Term): Context = {
-      val liftedExisting = types.map(existing => lift(existing, 1, 0))
-      Context(lift(typ, 1, 0) :: liftedExisting)
-    }
+    def extend(typ: Term): Context = Context(typ :: types)
   }
 
   object Context {
@@ -64,22 +61,28 @@ object Kernel {
     case Term.Const(name) => Term.Const(name)
   }
 
-  /** Substitutes a term for a de Bruijn index, shifting under binders as needed. */
-  def subst(term: Term, index: Int, replacement: Term): Term = term match {
-    case Term.Var(ix) if ix == index => replacement
+  /** Substitutes a term for a de Bruijn index at the given cutoff depth. */
+  def subst(term: Term, index: Int, replacement: Term, cutoff: Int): Term = term match {
+    case Term.Var(ix) if ix == index + cutoff => lift(replacement, cutoff, 0)
     case Term.Var(ix) => Term.Var(ix)
     case Term.Sort(level) => Term.Sort(level)
-    case Term.Pi(dom, cod) => Term.Pi(subst(dom, index, replacement), subst(cod, index + 1, lift(replacement, 1, 0)))
-    case Term.Lam(dom, body) => Term.Lam(subst(dom, index, replacement), subst(body, index + 1, lift(replacement, 1, 0)))
-    case Term.App(fn, arg) => Term.App(subst(fn, index, replacement), subst(arg, index, replacement))
+    case Term.Pi(dom, cod) =>
+      Term.Pi(subst(dom, index, replacement, cutoff), subst(cod, index, replacement, cutoff + 1))
+    case Term.Lam(dom, body) =>
+      Term.Lam(subst(dom, index, replacement, cutoff), subst(body, index, replacement, cutoff + 1))
+    case Term.App(fn, arg) =>
+      Term.App(subst(fn, index, replacement, cutoff), subst(arg, index, replacement, cutoff))
     case Term.Let(value, valueTy, body) =>
       Term.Let(
-        subst(value, index, replacement),
-        subst(valueTy, index, replacement),
-        subst(body, index + 1, lift(replacement, 1, 0))
+        subst(value, index, replacement, cutoff),
+        subst(valueTy, index, replacement, cutoff),
+        subst(body, index, replacement, cutoff + 1)
       )
     case Term.Const(name) => Term.Const(name)
   }
+
+  /** Substitutes a term for a de Bruijn index at the top level. */
+  def subst(term: Term, index: Int, replacement: Term): Term = subst(term, index, replacement, 0)
 
   /** Beta-reduces by substituting an argument into a lambda body. */
   def betaReduce(body: Term, arg: Term): Term = lift(subst(body, 0, lift(arg, 1, 0)), -1, 0)
@@ -124,13 +127,13 @@ object Kernel {
       env.lookup(name).map(_.typ).getOrElse(throw KernelError(s"Unknown constant $name"))
     case Term.Pi(dom, cod) =>
       val domSort = infer(env, ctx, dom)
-      val domLevel = ensureSort(domSort)
+      val domLevel = ensureSort(env, ctx, domSort)
       val codSort = infer(env, ctx.extend(dom), cod)
-      val codLevel = ensureSort(codSort)
+      val codLevel = ensureSort(env, ctx.extend(dom), codSort)
       Term.Sort(math.max(domLevel, codLevel))
     case Term.Lam(dom, body) =>
       val domSort = infer(env, ctx, dom)
-      ensureSort(domSort)
+      ensureSort(env, ctx, domSort)
       val bodyTy = infer(env, ctx.extend(dom), body)
       Term.Pi(dom, bodyTy)
     case Term.App(fn, arg) =>
@@ -142,7 +145,7 @@ object Kernel {
       }
     case Term.Let(value, valueTy, body) =>
       val valueTySort = infer(env, ctx, valueTy)
-      ensureSort(valueTySort)
+      ensureSort(env, ctx, valueTySort)
       check(env, ctx, value, valueTy)
       val bodyTy = infer(env, ctx.extend(valueTy), body)
       betaReduce(bodyTy, value)
@@ -156,7 +159,7 @@ object Kernel {
   }
 
   /** Ensures that a term is a sort and returns its universe level. */
-  private def ensureSort(term: Term): Int = term match {
+  private def ensureSort(env: Env, ctx: Context, term: Term): Int = whnf(env, ctx, term) match {
     case Term.Sort(level) => level
     case other => throw KernelError(s"Expected a sort, found $other")
   }

--- a/src/test/scala/KernelSuite.scala
+++ b/src/test/scala/KernelSuite.scala
@@ -11,6 +11,8 @@ class KernelSuite extends munit.FunSuite {
   private def baseEnv: Env = {
     val natDecl = ConstDecl(Sort(0), None, Reducibility.Opaque)
     val boolDecl = ConstDecl(Sort(0), None, Reducibility.Opaque)
+    val type0Decl = ConstDecl(Sort(1), Some(Sort(0)), Reducibility.Reducible)
+    val type0AliasDecl = ConstDecl(Const("Type0"), None, Reducibility.Opaque)
     val trueDecl = ConstDecl(Const("Bool"), None, Reducibility.Opaque)
     val falseDecl = ConstDecl(Const("Bool"), None, Reducibility.Opaque)
     val threeDecl = ConstDecl(Const("Nat"), None, Reducibility.Opaque)
@@ -66,6 +68,8 @@ class KernelSuite extends munit.FunSuite {
     Env.empty
       .addConstant("Nat", natDecl)
       .addConstant("Bool", boolDecl)
+      .addConstant("Type0", type0Decl)
+      .addConstant("A", type0AliasDecl)
       .addConstant("true", trueDecl)
       .addConstant("false", falseDecl)
       .addConstant("three", threeDecl)
@@ -104,9 +108,15 @@ class KernelSuite extends munit.FunSuite {
     assertEquals(reduced, Lam(Sort(0), Var(1)))
   }
 
-  test("context extension shifts existing entries") {
+  test("context extension preserves dependent references") {
     val ctx = Context.empty.extend(Sort(0)).extend(Var(0)).extend(Sort(0))
-    assertEquals(ctx.lookup(1), Some(Var(2)))
+    assertEquals(ctx.lookup(1), Some(Var(0)))
+  }
+
+  test("subst respects cutoff depth") {
+    val term = Var(2)
+    val result = Kernel.subst(term, 1, Var(0), 1)
+    assertEquals(result, Var(1))
   }
 
   test("whnf reduces let bindings") {
@@ -148,6 +158,13 @@ class KernelSuite extends munit.FunSuite {
     val t1 = Lam(Sort(0), Lam(Sort(0), Var(1)))
     val t2 = Lam(Sort(0), Lam(Sort(0), Var(1)))
     assert(Kernel.conv(Env.empty, Context.empty, t1, t2))
+  }
+
+  test("ensureSort reduces through definitional constants") {
+    val env = baseEnv
+    val term = Pi(Const("A"), Const("A"))
+    val inferred = Kernel.infer(env, Context.empty, term)
+    assert(Kernel.conv(env, Context.empty, inferred, Sort(0)))
   }
 
   test("infer id type") {


### PR DESCRIPTION
### Motivation

- Provide a small, self-contained kernel for dependently-typed checking and conversion to serve as the trusted core for the typing pipeline.
- Enable rigorous unit tests for de Bruijn operations, normalization (WHNF), conversion and basic dependent typing patterns used by the rest of the compiler.

### Description

- Add a minimal kernel implementation at `src/main/scala/com/github/peterzeller/minifumo/typing/kernel/Kernel.scala` implementing `Term` (de Bruijn `Var`, `Sort`, `Pi`, `Lam`, `App`, `Let`, `Const`), `Env`/`Context`, `lift`, `subst`, `betaReduce`, `whnf`, `conv`, `infer`, and `check` plus a simple `ConstDecl` with `Reducible | Opaque`.
- Use capture-safe de Bruijn shifting/substitution and a head-only `whnf` supporting β, ζ and δ (unfolding reducible constants), and an intensional conversion check that reduces to WHNF then structurally compares under binders.
- Add `src/test/scala/KernelSuite.scala` containing focused tests for de Bruijn correctness, WHNF behavior, conversion, and typing examples (identity `id`, `K`, `comp`, `let` usage), exercising both reducible/opaque constants and dependent function types.

### Testing

- Ran `sbt/bin/sbt scalafixAll` which completed successfully.
- Ran `sbt/bin/sbt test` which executed the existing suites plus the new `KernelSuite`, with all tests passing: Total 66 tests, 0 failed.
- The test suite covers shifting/substitution, beta-reduction/capture-avoidance, `let` reduction, δ-unfolding, conversion (β/δ), and inference/checking for `id`, `K`, `comp` and `let` examples as implemented in `KernelSuite`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dcf3a20ac832482d932fb62c90cda)