### PR TITLE
Fix unused code after scalafix

### DIFF
--- a/src/main/scala/com/github/peterzeller/minifumo/Main.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/Main.scala
@@ -131,19 +131,6 @@ object Main:
   private def loadProgram(path: Path, info: GlobalInfo): (ProgramFile, List[SyntaxError]) =
     info.parseCache.getOrElseUpdate(path, parseProgram(path))
 
-  // Resolves an import path relative to the project root, enforcing the .minifumo extension.
-  private def resolveImportPath(root: Path, pathText: String): Path =
-    val rawPath = Paths.get(pathText)
-    val withExtension =
-      if rawPath.toString.endsWith(".minifumo") then rawPath else Paths.get(s"${rawPath.toString}.minifumo")
-    root.resolve(withExtension).normalize()
-
-  // Finds the project root by walking up to locate minifumo.yml.
-  private def findProjectRoot(start: Path): Option[Path] =
-    Iterator.iterate(start)(_.getParent).takeWhile(_ != null).find { candidate =>
-      Files.exists(candidate.resolve("minifumo.yml"))
-    }
-
   // Renders a source range for error reporting.
   private def renderSourceRange(range: com.github.peterzeller.minifumo.ast.SourceRange): String =
     val start = range.start

--- a/src/main/scala/com/github/peterzeller/minifumo/interpreter/Interpreter.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/interpreter/Interpreter.scala
@@ -23,7 +23,7 @@ object Interpreter:
           if args.isEmpty then name else s"$name${args.map(_.toString).mkString("(", ", ", ")")}" 
         case Value.UnitVal => "unit"
         case Value.UndefinedVal => "undefined"
-        case Value.FuncVal(name, f) => s"<function $name>"
+        case Value.FuncVal(name, _) => s"<function $name>"
 
   /** Evaluates a function from the program by name. */
   def evalProg(prog: TypedAst.Program, funcName: String): Value =
@@ -33,7 +33,7 @@ object Interpreter:
       globals.update(symbol, buildCtorValue(symbol.name, arity))
     }
     functionBodies.foreach { case (symbol, info) =>
-      globals.update(symbol, buildFunctionValue(symbol.name, info.params, info.body, globals))
+      globals.update(symbol, buildFunctionValue(info.params, info.body, globals))
     }
     val entry = functionBodies.keys.find(_.name == funcName)
     entry match
@@ -70,7 +70,6 @@ object Interpreter:
 
   /** Builds a curried function value from its parameters and body. */
   private def buildFunctionValue(
-      name: String,
       params: List[TypedAst.ParamSymbol],
       body: TypedAst.Expr,
       globals: mutable.Map[TypedAst.Symbol, Value]
@@ -94,7 +93,6 @@ object Interpreter:
         locals.getOrElse(symbol, globals.getOrElse(symbol, Value.UndefinedVal))
       case TypedAst.Expr.Var(symbol) =>
         globals.getOrElse(symbol, Value.UndefinedVal)
-      case TypedAst.Expr.Var(_) => Value.UndefinedVal
       case TypedAst.Expr.App(callee, arg, _) =>
         val fn = evalExpr(callee, locals, globals)
         val argVal = evalExpr(arg, locals, globals)

--- a/src/main/scala/com/github/peterzeller/minifumo/parser/Parser.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/parser/Parser.scala
@@ -2,7 +2,7 @@ package com.github.peterzeller.minifumo.parser
 import com.github.peterzeller.minifumo.antlr.MinifumoParser
 import com.github.peterzeller.minifumo.antlr.MinifumoParser.ProgramContext
 import com.github.peterzeller.minifumo.lexer.ExtendedLexer.ExtendedMinifumoLexer
-import org.antlr.v4.runtime.{ANTLRErrorListener, CharStream, CodePointCharStream, Parser}
+import org.antlr.v4.runtime.{ANTLRErrorListener, CharStream, Parser}
 import org.antlr.v4.runtime.atn.ATNConfigSet
 import org.antlr.v4.runtime.dfa.DFA
 

--- a/src/main/scala/com/github/peterzeller/minifumo/typing/GlobalSymbols.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/typing/GlobalSymbols.scala
@@ -2,7 +2,7 @@ package com.github.peterzeller.minifumo.typing
 
 import com.github.peterzeller.minifumo.ast
 import com.github.peterzeller.minifumo.ast.{AstTransform, SourceRange}
-import com.github.peterzeller.minifumo.parser.{SyntaxError, parseFile, parseInput}
+import com.github.peterzeller.minifumo.parser.{SyntaxError, parseFile}
 import com.github.peterzeller.minifumo.typing.TypeChecker.TypeError
 import com.github.peterzeller.minifumo.typing.TypedAst.Expr.UnknownType
 import com.github.peterzeller.minifumo.typing.TypedAst.{ErrorSymbol, Expr, GlobalNameSymbol, LocalSymbol}
@@ -187,7 +187,6 @@ trait NameCache:
 class ProjectSymbolCache(projectRoot: Path) extends NameCache:
   private var astCache: Map[Path, (ast.ProgramFile, List[SyntaxError])] = Map()
   private var namesCache: Map[Path, Map[String, GlobalName]] = Map()
-  private var symbolCache: Map[Path, GlobalSymbols] = Map()
 
   def toPath(importPath: String): Path =
     projectRoot.resolve(importPath)

--- a/src/main/scala/com/github/peterzeller/minifumo/typing/TypeChecker.scala
+++ b/src/main/scala/com/github/peterzeller/minifumo/typing/TypeChecker.scala
@@ -56,10 +56,10 @@ object TypeChecker:
     val idSupply = IdSupply()
     val metaStore = MetaStore()
     val globals = buildGlobals(program, importedExports)
-    val signatureInfo = buildSignatures(program, globals, errors, idSupply)
+    val signatureInfo = buildSignatures(program, globals, idSupply)
     val typedItems = program.items.map {
       case decl: ast.TopLevel.DataDecl =>
-        buildDataDecl(decl, globals, errors, idSupply)
+        buildDataDecl(decl, globals, idSupply)
       case decl: ast.TopLevel.FunDecl =>
         val info = signatureInfo(decl.sig.name)
         val context = TypeContext(globals, Map())
@@ -148,7 +148,7 @@ object TypeChecker:
     val importedTypes = importedExports.types.map { case (name, source) =>
       name -> TypedAst.DatatypeSymbol(name, Paths.get(source))
     }
-    val importedFunctions = importedExports.functions.map { case (name, source) =>
+    val importedFunctions = importedExports.functions.map { case (name, _) =>
       name -> TypedAst.FunctionSymbol(name, TypedAst.Expr.UnknownType()(ast.SourceRange.empty))
     }
     val programTypes = program.items.collect {
@@ -178,7 +178,6 @@ object TypeChecker:
   private def buildSignatures(
       program: ast.ProgramFile,
       globals: GlobalEnv,
-      errors: ListBuffer[TypeError],
       idSupply: IdSupply
     ): Map[String, FunctionInfo] =
     val functionInfos = mutable.Map[String, FunctionInfo]()
@@ -214,14 +213,12 @@ object TypeChecker:
           val symbol = globals.functions.getOrElse(decl.sig.name, TypedAst.FunctionSymbol(decl.sig.name, funType)).copy(tpe = funType)
           globals.functions.update(decl.sig.name, symbol)
           functionInfos.update(decl.sig.name, FunctionInfo(symbol, implicitParams, explicitParams, returnType))
-        case _ =>
     functionInfos.toMap
 
   /** Builds a typed data declaration. */
   private def buildDataDecl(
       decl: ast.TopLevel.DataDecl,
       globals: GlobalEnv,
-      errors: ListBuffer[TypeError],
       idSupply: IdSupply
     ): TypedAst.TopLevel =
     val typeParams = decl.implicitParams.map(_.name)
@@ -377,7 +374,7 @@ object TypeChecker:
               check(arg, dom).map { argExpr =>
                 TypedAst.Expr.App(appliedExpr, argExpr, cod)(expr.source) -> cod
               }
-            case other => Left(List(TypeError("Expected a function", expr.source)))
+            case _ => Left(List(TypeError("Expected a function", expr.source)))
         }
       case ast.Expr.CallImplicit(callee, arg) =>
         infer(callee).flatMap { (calleeExpr, calleeType) =>


### PR DESCRIPTION
### Motivation
- Remove and refactor code flagged as unused by `scalafix` to eliminate warnings and simplify implementation. 
- Tighten function signatures and pattern matches to avoid unused parameters and unreachable cases. 
- Drop needless scaffolding and imports to keep module responsibilities focused and clean.

### Description
- Removed unused helper methods `resolveImportPath` and `findProjectRoot` from `Main.scala`. 
- Simplified `Interpreter.scala` by ignoring the unused function closure parameter in `Value.FuncVal` display, removing the unused `name` parameter from `buildFunctionValue`, updating call sites, and removing a duplicate unreachable `Var` case. 
- Trimmed parser imports by removing `CodePointCharStream` from `Parser.scala`. 
- Removed an unused `parseInput` import and the unused `symbolCache` field from `GlobalSymbols.scala`, and kept only the active caches. 
- Cleaned up `TypeChecker.scala` by dropping unused `errors` parameters from `buildSignatures` and `buildDataDecl`, ignoring an unused tuple element when mapping imported functions, and replacing unused match variables with wildcards.

### Testing
- Ran `sbt/bin/sbt scalafix` and the run completed successfully. 
- Ran `sbt/bin/sbt test` and all automated tests passed (`Passed: Total 20, Failed 0, Errors 0, Ignored 3`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982ef3764248324991db0641ee62d4c)