### PR TITLE
Adjust theme toggle label and add theming for word-card components

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -467,7 +467,7 @@ export function App() {
         </button>
         <h1 className="topBarTitle">{activePageTitle}</h1>
         <button onClick={() => setTheme((current) => (current === 'dark' ? 'light' : 'dark'))} className="themeToggleButton">
-          {theme === 'dark' ? 'Light' : 'Dark'}
+          {theme === 'dark' ? 'Bright' : 'Dark'}
         </button>
       </header>
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -11,6 +11,9 @@
   --button-secondary-text: #1e3a8a;
   --editor-bg: #f8fafc;
   --editor-text: #0f172a;
+  --word-card-bg: #ffffff;
+  --word-card-text: #0f172a;
+  --word-card-border: #cbd5e1;
   color-scheme: light;
 }
 
@@ -26,6 +29,9 @@
   --button-secondary-text: #dbe7ff;
   --editor-bg: #020617;
   --editor-text: #e2e8f0;
+  --word-card-bg: #1e293b;
+  --word-card-text: #f9fafb;
+  --word-card-border: #475569;
   color-scheme: dark;
 }
 
@@ -263,6 +269,23 @@ button:disabled {
   gap: 0.75rem;
   margin-top: auto;
   padding-top: 1rem;
+}
+
+.wordCard,
+.word-card,
+.sentenceWordCard,
+.sentence-word-card,
+.translationWordCard,
+.translation-word-card,
+button.wordCard,
+button.word-card,
+button.sentenceWordCard,
+button.sentence-word-card,
+button.translationWordCard,
+button.translation-word-card {
+  background: var(--word-card-bg);
+  color: var(--word-card-text);
+  border: 1px solid var(--word-card-border);
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
### Motivation
- Improve the theme toggle wording for clarity in dark mode and provide consistent visual styling for word/sentence/translation card components across light and dark themes.

### Description
- Change the theme toggle label in `App.tsx` to display `Bright` when `theme === 'dark'` and `Dark` otherwise.
- Add CSS variables `--word-card-bg`, `--word-card-text`, and `--word-card-border` to `:root` and `:root[data-theme='dark']` in `styles.css`.
- Add rules for `.wordCard`, `.word-card`, `.sentenceWordCard`, `.sentence-word-card`, `.translationWordCard`, `.translation-word-card` and their `button.` variants to apply the new variables for background, text color, and border.

### Testing
- Ran `yarn build` to verify TypeScript compilation and the production build succeeded.
- Ran `yarn test` and the existing automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf86ab91008324a44490b3bc1c1442)