### PR TITLE
Add manual `workflow_dispatch` with selectable ref and run CI/deploy for dispatched runs

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -10,6 +10,12 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to deploy"
+        required: true
+        default: "main"
 
 permissions:
   contents: read
@@ -25,7 +31,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -78,7 +87,7 @@ jobs:
         run: npm run build
 
       - name: Build web frontend for deployment (TypeScript + Scala.js)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
         working-directory: web
         env:
           VITE_BASE_PATH: /minifumo-lang/
@@ -99,17 +108,17 @@ jobs:
         run: npm run test:e2e
 
       - name: Configure Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@v3
         with:
           path: web/dist
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
### Motivation

- Enable running the repository CI and GitHub Pages deployment manually against an arbitrary branch, tag, or commit using `workflow_dispatch` and a selectable `ref` input.

### Description

- Add a `workflow_dispatch` trigger with a `ref` input to the Scala CI workflow so manual runs can specify which ref to build. 
- Update the `actions/checkout@v4` step to supply the chosen `ref` when the event is `workflow_dispatch` and give the step an explicit name. 
- Relax conditional guards on build, web build, Pages configuration, artifact upload, and the `deploy` job to also run when the event is `workflow_dispatch`. 
- Keep existing setup steps for JDK, sbt, Node, Lean, Playwright, and the same build/test steps while enabling them for manual dispatches.

### Testing

- The CI workflow is configured to run the existing automated checks including `scalafix` checks, `sbt test`, `sbt "testOnly com.github.peterzeller.minifumo.TutorialExamplesSuite"`, the Scala.js build steps, `npm run build` for the web frontend, and Playwright e2e tests via `npm run test:e2e`.
- These checks will now run on `push` to `main` and on manual `workflow_dispatch` runs targeting the specified `ref`.
- No automated CI run results are included in this PR description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd494ff1388324acc2ce71b32ca789)